### PR TITLE
[WIP] Added delete command (Currently only works for search)

### DIFF
--- a/pilot/client.py
+++ b/pilot/client.py
@@ -3,7 +3,7 @@ import time
 import requests
 import globus_sdk
 import urllib
-from globus_sdk import AuthClient, SearchClient
+from globus_sdk import AuthClient, SearchClient, TransferClient
 from fair_research_login import (NativeClient, LoadError)
 from pilot.config import config
 
@@ -56,6 +56,11 @@ class PilotClient(NativeClient):
     def gsearch(self):
         authorizer = self.get_authorizers()['search.api.globus.org']
         return SearchClient(authorizer=authorizer)
+
+    @property
+    def gtransfer(self):
+        authorizer = self.get_authorizers()['transfer.api.globus.org']
+        return TransferClient(authorizer=authorizer)
 
     @property
     def http_headers(self):
@@ -135,6 +140,20 @@ class PilotClient(NativeClient):
             # sc.delete_entry(self.SEARCH_INDEX_TEST, subject)
             raise Exception('Failed to ingest search subject')
         return True
+
+    def delete_entry(self, dataframe, directory, test, entry_id=None):
+        """
+        Short path is the name of the file and subdirectory under
+        BASE_DIR
+        :param short_path:
+        :param test: Delete the subject on the test index
+        :return:
+        """
+        return self.gsearch.delete_entry(
+            self.get_index(test),
+            self.get_subject_url(dataframe, directory, test),
+            entry_id=entry_id
+        )
 
     def upload(self, dataframe, destination, test=False):
         filename = os.path.basename(dataframe)

--- a/pilot/commands/main.py
+++ b/pilot/commands/main.py
@@ -2,7 +2,7 @@ import click
 
 from pilot.version import __version__
 from pilot.commands.auth import auth_commands
-from pilot.commands.search import search_commands
+from pilot.commands.search import search_commands, delete
 from pilot.commands.transfer import transfer_commands, status_commands
 
 
@@ -22,6 +22,7 @@ cli.add_command(auth_commands.whoami)
 
 cli.add_command(search_commands.list_command)
 cli.add_command(search_commands.describe)
+cli.add_command(delete.delete_command)
 
 cli.add_command(transfer_commands.upload)
 cli.add_command(transfer_commands.download)

--- a/pilot/commands/search/delete.py
+++ b/pilot/commands/search/delete.py
@@ -1,0 +1,39 @@
+import click
+import os
+import globus_sdk
+
+from pilot.client import PilotClient
+
+
+@click.command(name='delete', help='Delete a search entry')
+@click.argument('path', type=click.Path())
+@click.option('--test', is_flag=True, default=False)
+@click.option('--dry-run', is_flag=True, default=False,
+              help="Show report, but don't actually delete entry/file")
+@click.option('--delete-data', 'delete_data', default=False,
+              help='Output as JSON.')
+@click.option('--yes', is_flag=True)
+def delete_command(path, test, dry_run, delete_data, yes):
+    pc = PilotClient()
+    if not pc.is_logged_in():
+        click.echo('You are not logged in.')
+        return
+
+    fname, dirname = os.path.basename(path), os.path.dirname(path)
+
+    sub_url = pc.get_subject_url(fname, dirname, test)
+    if dry_run:
+        click.secho('Dry Run (No Delete Performed)')
+        click.secho('Search Entry: {}'.format(sub_url))
+        click.secho('File: {}'.format(pc.get_path(fname, dirname, test)))
+        return
+
+    try:
+        pc.delete_entry(fname, dirname, test)
+        click.secho('Removed {} Successfully'.format(path), fg='green')
+    except globus_sdk.exc.SearchAPIError as se:
+        if se.code == 'NotFound.Generic':
+            click.secho('{} does not exist, or cannot be found at your '
+                        'permission level.'.format(path), fg='yellow')
+        else:
+            click.secho(str(se))


### PR DESCRIPTION
The delete command lets the user delete search subjects by short path. For example: 

    pilot delete metadata/celllines.tsv

Supports test and dry-run flags:

    pilot delete --test --dry-run something/important.tsv

Does not delete data yet.