### PR TITLE
Project updates

### DIFF
--- a/docs/project-admin.rst
+++ b/docs/project-admin.rst
@@ -9,12 +9,12 @@ Introduction
 
 This is guide to using ``pilot`` to create and manage projects and the datasets associated with them.
               
-Prequisites
-^^^^^^^^^^^
+Prerequisites
+^^^^^^^^^^^^^
 
-TODO
+You should review the `User Guide
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/user-guide.rst>`_ for:
 
-You should review the user guide (add link) to
 
 - installing and configuring ``pilot``
 - listing and downloading files
@@ -22,7 +22,11 @@ You should review the user guide (add link) to
 What is a Project?
 ------------------
 
-TODO
+A project is a searchable group of files and directories. When you create a new project,
+all Pilot commands (list, describe, upload, download) will apply only to the files in
+this project.
+
+A project consists of:
 
 - Datasets description?
 
@@ -34,39 +38,110 @@ TODO
 - A web site for searching for and downloading the files
 - Groups to manage access to the files and metadata
 
+See the `User Guide Projects Section <https://github.com/globusonline/pilot1-tools/blob/master/docs/user-guide.rst#id6>`_
+for info on listing, setting, and displaying information about projects.
 
 Creating a Project
 ------------------
 
-TODO
+Create a project with the following:
 
-What happens when a project is created?
+.. code-block:: bash
+
+   pilot project add
 
 
-Adding Datasets to a Project
-----------------------------
+You will be brought through an interactive prompt similar to the one below:
 
-TODO
 
-Updating Datasets
------------------
+.. code-block:: bash
 
-TODO
+   Pick a title for your new project (My New Project)>
+   Pick a short name (my-new-project)>
+   Describe your new project (This project is intended to do X for scientists)>
+   Set your Globus Group (NCI Users)>
+   Summary:
+   title               My New Project
+   short_name          my-new-project
+   description         This project is intended to do X for scientists
+   group               NCI Users
+   Continue with these values? (y/n)
 
-- Metadata
-- Files
+The interactive prompt will try to choose sensible defaults. If your answer
+isn't valid (such as the project name already exists), the prompt will ask you
+to choose another. You can also type 'help' for more info, or 'q' to quite the
+interactive prompt.
+
+- Project Title: This will be displayed in the portal
+- Short Name: This will act as the URL path for your portal
+- Description: This will be shown in the portal on the 'projects' page
+- Group: This Globus Group determines who can access the data you upload
+
+
+
+Uploading Datasets to a Project
+-------------------------------
+
+Prerequisites: Make sure your project is set! You can check this with the ``pilot project`` command.
+
+Upload datasets to your project with the ``upload`` subcommand.
+
+Given the file example.tsv:
+
+.. code-block:: tsv
+
+   Numbers Title
+   5       foo
+   6       foo
+
+We can upload ``example.tsv`` to our project with:
+
+.. code-block:: bash
+
+   pilot upload example.tsv /
+
+If you want to place your file inside a folder, such as after running ``pilot mkdir myfolder``,
+you can provide the relative path instead:
+
+.. code-block:: bash
+
+   pilot upload example.tsv myfolder
+
+
+The above command will upload a file to the root directory of your project.
+It will now be visible in the portal, and will show up when doing a ``pilot list``
+or ``pilot describe example.tsv``.
+
+You may notice some fields are missing from the metadata. Pilot will attempt to
+gather as much metadata as possible about the file you are uploading, but you can
+supplement the data by providing a JSON document ``example_metadata.json``:
+
+.. code-block:: json
+
+    {
+        "data_type": "Metadata",
+        "dataframe_type": "List,
+    }
+
+You can add a metadata JSON document with the ``-j`` flag.
+
+
+.. code-block:: bash
+
+   pilot upload -j my_metadata.json example.tsv /
+
+You can find more info about what to include in ``my_metadata.json`` in the `Reference Guide
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/reference.rst>`_.
+
 
 Deleting Datasets
 -----------------
 
-TODO
+Deleting datasets removes both the file and the search record. Like the ``describe`` command,
+you will refer to the search record by its relative path within the project.
 
-- Full dataset
-- Individual files
+Delete the above example file ``example.tsv`` with the following:
 
 .. code-block:: bash
 
-   pilot project 
-   Set project with "pilot project set <myproject>"
-     * ncipilot1
-     ncipilot1-test
+   pilot delete myfolder/example.tsv

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1,0 +1,62 @@
+pilot1-tools Reference
+======================
+
+.. contents:: Table of Contents
+
+
+Metadata
+--------
+
+
+Project Metadata
+~~~~~~~~~~~~~~~~
+
+Project Metadata can be added when uploading to enrich your search results and make them
+more discoverable to users of your project.
+
+Here are an example of supported fields which can be added to your project:
+
+.. code-block:: json
+
+    "data_type": {
+        "type": "string",
+        "description" : "Data category, such as 'Metadata' or 'Physics Experiment'"
+                    },
+    "dataframe_type": {
+        "type": "string",
+        "enum": ["List", "Matrix"],
+        "description" : "Dataframe structure, matrix or list"
+    },
+    "x-label": {
+        "type": "string",
+        "description": "X-label, if the dataframe_type is Matrix"
+    },
+    "y-label": {
+        "type": "string",
+        "description": "Y-label, if the dataframe_type is Matrix"
+    },
+    "units": {
+        "type": "integer",
+        "description": "Units or scale (e.g., log, log10) of the data."
+    },
+    "source": {
+        "type": "array",
+        "description": "The source data repositories.",
+        "items": {
+            "type": "string",
+            "description": "One repository."
+        }
+    }
+
+Example my_metadata.json:
+
+.. code-block:: json
+
+    {
+        "data_type": "Metadata",
+        "dataframe_type": "List,
+    }
+
+``pilot upload -j my_metadata.json myfile.txt /``
+
+This will upload myfile.txt with additional metadata.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -61,28 +61,32 @@ Working with Projects
 Update & List Projects
 ^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Use ``pilot project`` to list available projects. An asterisk (*) marks
+your currently selected project. Other commands, such as ``pilot list``, will
+automatically use the project you select.
+
+.. code-block:: bash
+
+   pilot project
+   Set project with "pilot project set <myproject>"
+     * monty-python-discussions
+     pilot-tutorial
+
+
+Projects may be updated at any time. The Pilot CLI will check for updates every 24 hours,
+but you can check any time with the following:
 
 .. code-block:: bash
 
    pilot project update
-   removed
-   added
-   changed
-
-
-.. code-block:: bash
-
-   pilot project 
-   Set project with "pilot project set <myproject>"
-     ncipilot1
-     ncipilot1-test
+   Added:
+      > monty-python-and-the-holy-grail
 
    
 Setting Your Current Project
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Change your project with the ``project set`` subcommand:
 
 .. code-block:: bash
 
@@ -96,23 +100,6 @@ TODO
    Set project with "pilot project set <myproject>"
      ncipilot1
      * ncipilot1-test
-
-
-Changing Your Current Project
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   pilot project set ncipilot1
-   Current project set to ncipilot1
-
-
-.. code-block:: bash
-
-   pilot project 
-   Set project with "pilot project set <myproject>"
-     * ncipilot1
-     ncipilot1-test
 
 
 Working with Datasets

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -90,8 +90,8 @@ Change your project with the ``project set`` subcommand:
 
 .. code-block:: bash
 
-   pilot project set ncipilot1-test
-   Current project set to ncipilot1-test
+   pilot project set pilot-tutorial
+   Current project set to pilot-tutorial
 
 
 .. code-block:: bash
@@ -99,24 +99,82 @@ Change your project with the ``project set`` subcommand:
    pilot project 
    Set project with "pilot project set <myproject>"
      ncipilot1
-     * ncipilot1-test
+     * pilot-tutorial
 
 
 Working with Datasets
 ---------------------
 
-TODO
+Each Dataset represents a file on Petrel and a corresponding search entry in
+Globus Search. You can discover datasets with the  ``list`` and ``describe``
+commands, and fetch data using the ``download`` command.
+
+Each of these commands will only act on datasets within your selected _project_.
 
 Listing Datasets
 ^^^^^^^^^^^^^^^^
 
-Searching for Datasets
-^^^^^^^^^^^^^^^^^^^^^^
+Use the list command to see all of the datasets for this project:
+
+.. code-block:: bash
+
+   pilot list
+   Title                Data       Dataframe Rows   Column Size   Path
+   example.tsv                               95     2      674    myfolder/example.tsv
+
+This will list high level general info about datasets in this project, in addition to
+a **path** we can use to refer to a specific dataset. For this example, we would refer
+to the dataset "example.tsv" above using ``myfolder/example.tsv``
+
+
+Describing Datasets
+^^^^^^^^^^^^^^^^^^^
+
+Use ``pilot describe <dataset>`` to get detailed info about a dataset.
+
+In the ``pilot list`` example above, we saw there was one record with the path
+"myfolder/example.tsv". Running the following command gives us the following
+output:
+
+.. code-block:: bash
+
+   pilot describe myfolder/example.tsv
+   Title                example.tsv
+   Authors              Curie, Marie
+   Publisher            University of Paris
+   Subjects             radium
+                        physics
+   Dates                Created:  Thursday, Jun 27, 1910
+   Data
+   Dataframe
+   Rows                 95
+   Columns              2
+   Formats              text/tab-separated-values
+   Version              1
+   Size                 674
+   Description
+
+
+   Column Name          Type    Count  Freq Top         Unique Min    Max    Mean   Std    25-PCTL 50-PCTL 75-PCTL
+   Numbers              float64 95                             5.0    99.0   52.0   27.568 28.5    52.0    75.5
+   Title                string  95     50   baz         3
+
+   Other Data
+   Subject              globus://ebf55996-33bf-11e9-9fa4-0a06afd4a22e/projects/pilot_tutorial_5/simple.tsv
+   Portal               https://petreldata.net/nci-pilot1/detail/globus%253A%252F%252Febf55996-33bf-11e9-9fa4-0a06afd4a22e%252Fprojects%252Fpilot_tutorial_5%252Fsimple.tsv
+
+
 
 Downloading Datasets
 ^^^^^^^^^^^^^^^^^^^^
 
-TODO
+Use ``pilot download <dataset>`` to download a dataset. Using the example above, where
+"myfolder/example.tsv" is a dataset we discovered from the ``pilot list`` command:
 
-- Describe Globus vs. HTTPS
-- Add ``set endpoint <endpoint>:<path>`` to override GCP
+
+.. code-block:: bash
+
+   pilot describe myfolder/example.tsv
+   Saved example.tsv
+
+

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -128,6 +128,30 @@ class PilotClient(NativeClient):
             urllib.parse.urlencode(params), ''
         ])
 
+    def get_portal_url(self, path=None, project=None):
+        """
+        Get a URL to the subject at petreldata.net. If project is none, the
+        current project is used. If path is none, a url to the project is
+        generated instead of a link to a subject.
+        :param path:
+        :param project:
+        :return:
+        """
+        project = project or self.project.current
+        index = self.get_index(project)
+        index_slug_map = {
+            '889729e8-d101-417d-9817-fa9d964fdbc9': 'nci-pilot1',
+            'e0849c9b-b709-46f3-be21-80893fc1db84': 'nci-pilot1-test',
+        }
+        index_slug = index_slug_map.get(index)
+        if path:
+            sub = self.get_subject_url(path, project=project)
+            sub = urllib.parse.quote_plus(urllib.parse.quote_plus(sub))
+            return 'https://petreldata.net/{}/projects/{}/{}/'.format(
+                index_slug, project, sub)
+        return 'https://petreldata.net/{}/projects/{}/'.format(index_slug,
+                                                               project)
+
     def get_subject_url(self, path, project=None, relative=True):
         return self.get_globus_url(path, project, relative)
 

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -73,7 +73,7 @@ class PilotClient(NativeClient):
                                              base_url=base_url)
 
     def get_group(self, project=None):
-        return self.project.get_info(project)['group']
+        return self.project.get_info(project)['group'] or 'public'
 
     def get_endpoint(self, project=None):
         return self.project.get_info(project)['endpoint']

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -102,7 +102,7 @@ class PilotClient(NativeClient):
                 path = bdir
         else:
             if bdir not in path:
-                raise exc.PilotClientException(
+                log.warning(
                     'Absolute path {} not in project {} path {}'.format(
                         path, project or self.project.current, bdir)
                 )

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -175,7 +175,7 @@ class PilotClient(NativeClient):
         except globus_sdk.exc.SearchAPIError:
             return None
 
-    def ingest_entry(self, gmeta_entry):
+    def ingest_entry(self, gmeta_entry, index=None):
         """
         Ingest a complete gmeta_entry into search. If test is true, the test
         search index will be used instead.
@@ -186,9 +186,10 @@ class PilotClient(NativeClient):
         :return: True on success Raises exception on fail
         """
         sc = self.get_search_client()
-        result = sc.ingest(self.get_index(), gmeta_entry)
+        index = index or self.get_index()
+        result = sc.ingest(index, gmeta_entry)
         pending_states = ['PENDING', 'PROGRESS']
-        log.debug(f'Ingesting to {self.get_index()}')
+        log.debug('Ingesting to {}'.format(index))
         task_status = sc.get_task(result['task_id'])['state']
         while task_status in pending_states:
             log.debug(f'Search task still {task_status}')

--- a/pilot/commands/path_utils.py
+++ b/pilot/commands/path_utils.py
@@ -1,0 +1,3 @@
+
+def slug_to_path(slug):
+    return slug.replace('-', '_')

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -85,7 +85,7 @@ def upload(dataframe, destination, metadata, gcp, update, test, dry_run,
         new_metadata = update_metadata(new_metadata, prev_metadata,
                                        user_metadata)
         subject = pc.get_subject_url(short_path)
-        gmeta = gen_gmeta(subject, pc.get_group(), new_metadata)
+        gmeta = gen_gmeta(subject, [pc.get_group()], new_metadata)
     except (RequiredUploadFields, ValidationError) as e:
         click.secho('Error Validating Metadata: {}'.format(e), fg='red')
         return 1

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -53,16 +53,15 @@ def upload(dataframe, destination, metadata, gcp, update, test, dry_run,
     if not destination:
         dirs = pc.ls('')
         click.echo('No Destination Provided. Please select one from the '
-                   'directory:\n{}'.format('\t '.join(dirs)))
+                   'directory or "/" for root:\n{}'.format('\t '.join(dirs)))
         return
 
     try:
         pc.ls(destination)
     except globus_sdk.exc.TransferAPIError as tapie:
         if tapie.code == 'ClientError.NotFound':
-            url = pc.get_globus_app_url('')
-            click.secho('Directory does not exist: "{}"\nPlease create it at: '
-                        '{}'.format(destination, url), err=True, bg='red')
+            click.secho('Directory does not exist: "{}"'.format(destination),
+                        err=True, fg='yellow')
             return 1
         else:
             click.secho(tapie.message, err=True, bg='red')
@@ -143,11 +142,12 @@ def upload(dataframe, destination, metadata, gcp, update, test, dry_run,
         tl = transfer_log.TransferLog()
         tl.add_log(transfer_result, short_path)
         click.echo('{}. You can check the status below: \n'
-                   'https://app.globus.org/activity/{}/overview\n'
-                   'URL will be: {}'.format(
+                   'https://app.globus.org/activity/{}/overview\n'.format(
                         transfer_result['message'], transfer_result['task_id'],
-                        url)
+                        )
                    )
+        click.echo('You can find your result here: {}'.format(
+            pc.get_portal_url(short_path)))
     else:
         click.echo('Uploading data...')
         response = pc.upload(dataframe, destination)
@@ -156,6 +156,7 @@ def upload(dataframe, destination, metadata, gcp, update, test, dry_run,
         else:
             click.echo('Failed with status code: {}'.format(
                 response.status_code))
+            return
 
 
 @click.command(help='Download a file to your local directory.')

--- a/pilot/schemas/project_metadata.json
+++ b/pilot/schemas/project_metadata.json
@@ -15,8 +15,7 @@
                 },               
                 "data_type": {
                     "type": "string",
-                    "enum": ["Metadata", "Drug Response", "Microarray", "RNA-seq", "Reference", "Drug Descriptor"],
-                    "description" : "Data category, may be: 'Drug Descriptor', 'Drug Response', 'Microarray', 'RNA-seq', 'Reference', 'Drug Descriptor'"
+                    "description" : "Data category, such as 'Metadata' or 'Physics Experiment'"
                                 },
                 "dataframe_type": {
                     "type": "string",

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -231,8 +231,11 @@ def gen_gmeta(subject, visible_to, content):
         if any([m in ve.message for m in MINIMUM_USER_REQUIRED_FIELDS]):
             raise RequiredUploadFields(ve.message,
                                        MINIMUM_USER_REQUIRED_FIELDS) from None
+    visible_to = [vt if vt == 'public' else GROUP_URN_PREFIX.format(vt)
+                  for vt in visible_to]
+    log.debug('visible_to for {} set to {}'.format(subject, visible_to))
     entry = GMETA_ENTRY.copy()
-    entry['visible_to'] = [GROUP_URN_PREFIX.format(visible_to)]
+    entry['visible_to'] = visible_to
     entry['subject'] = subject
     entry['content'] = content
     entry['id'] = 'metadata'

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -131,4 +131,7 @@ def mock_cli(mock_cli_basic, mock_transfer_client):
     mock_cli_basic.ls = Mock()
     mock_cli_basic.mkdir = Mock()
     mock_cli_basic.delete_entry = Mock()
+    mock_cli_basic.get_search_client = Mock()
+    mock_cli_basic.get_transfer_client = Mock()
+    mock_cli_basic.get_auth_client = Mock()
     return mock_cli_basic

--- a/tests/unit/test_client_path_resolution.py
+++ b/tests/unit/test_client_path_resolution.py
@@ -1,7 +1,7 @@
 import pytest
 from urllib.parse import urlparse
 from pilot.client import PilotClient
-from pilot.exc import PilotInvalidProject, PilotClientException
+from pilot.exc import PilotInvalidProject
 
 from tests.unit.mocks import MOCK_PROJECTS
 
@@ -40,13 +40,6 @@ def test_special_paths(mock_projects):
     assert pc.get_path('.') == '/foo_folder'
     assert pc.get_path('..') == '/foo_folder'
     assert pc.get_path('/foo/bar/baz.txt') == '/foo_folder/foo/bar/baz.txt'
-
-
-def test_absolute_path_without_project_dir_raises_error(mock_projects):
-    pc = PilotClient()
-    pc.project.current = 'foo-project'
-    with pytest.raises(PilotClientException):
-        pc.get_path('not-in-foo-project', relative=False)
 
 
 def test_get_globus_http_url(mock_projects):


### PR DESCRIPTION
Two major things come with this update:

* The project manifest is no longer held on petrel, instead it is ingested directly into search. 
* Adding new projects has been streamlined, and the master manifest is automatically updated after a new project has been added.
* Project 'paths' have been removed and automatically determined based on the 'project slug' in the 'projects' directory. 

This takes care of everything in #39 and #40 