### PR TITLE
Added docs, simplified readme, updated user-guide install, added build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,39 +9,6 @@ A Command Line tool for managing data in Globus Search as well as transferring c
 Installation
 ------------
 
-Pilot1 tools supported on Python 3.5 and higher
-
-Install with pip:
-
-.. code-block:: python
-
-    pip install -e git+git@github.com:globusonline/pilot1-tools.git#egg=pilot1-tools
-
-
-You will also need Globus Connect Personal installed on your machine. You can download
-a copy here: https://www.globus.org/globus-connect-personal
-
-
-Mac OSX
-~~~~~~~
-
-For Mac OSX, you may need to install headers. Ensure XCode is installed
-
-.. code-block:: bash
-
-    xcode-select --install
-
-Headers for Mac have moved recently, causing some components not to install. You can reinstall
-the old headers here:
-
-.. code-block:: bash
-
-    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
-
-
-Conda
-~~~~~
-
 These tools are available on Conda for Python 3.6, you can install them with the following:
 
 .. code-block:: bash
@@ -49,8 +16,19 @@ These tools are available on Conda for Python 3.6, you can install them with the
     conda create -n pilot1-env -c conda-forge -c nickolaussaint pilot1-tools
 
 
-Usage
------
+You can see the `Developer Guide Installation
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/developer-guide.rst>`_ for more options.
+
+
+Quick Start
+-----------
+
+For a full walkthrough, see the `User Guide
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/user-guide.rst>`_.
+Administrators can also view the `Admin Guide
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/project-admin.rst>`_.
+
+A quick walkthrough is below.
 
 First, login using Globus:
 

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -1,0 +1,59 @@
+pilot1-tools Developer Guide
+============================
+
+.. contents:: Table of Contents
+
+Introduction
+------------
+
+This guide includes general instructions for more advanced users that may not
+be necessary for users or admins.
+
+Installation
+------------
+
+There are a couple of different options. You can either install the latest stable
+version on Conda, or the latest development changes from github.
+
+
+Conda
+~~~~~
+
+These tools are available on Conda for Python 3.6, you can install them with the following:
+
+.. code-block:: bash
+
+    conda create -n pilot1-env -c conda-forge -c nickolaussaint pilot1-tools
+
+
+Github
+~~~~~~
+
+Pilot1 tools supported on Python 3.5 and higher
+
+Install with pip:
+
+.. code-block:: python
+
+    pip install -e git+git@github.com:globusonline/pilot1-tools.git#egg=pilot1-tools
+
+
+You will also need Globus Connect Personal installed on your machine. You can download
+a copy here: https://www.globus.org/globus-connect-personal
+
+
+Mac OSX
+~~~~~~~
+
+For Mac OSX, you may need to install headers. Ensure XCode is installed
+
+.. code-block:: bash
+
+    xcode-select --install
+
+Headers for Mac have moved recently, causing some components not to install. You can reinstall
+the old headers here:
+
+.. code-block:: bash
+
+    open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg

--- a/docs/project-admin.rst
+++ b/docs/project-admin.rst
@@ -15,7 +15,6 @@ Prerequisites
 You should review the `User Guide
 <https://github.com/globusonline/pilot1-tools/blob/master/docs/user-guide.rst>`_ for:
 
-
 - installing and configuring ``pilot``
 - listing and downloading files
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -3,25 +3,47 @@ pilot1-tools User Guide
 
 .. contents:: Table of Contents
 
+Introduction
+------------
+
+NCI Pilot Tools are a suite of command line utilities for quickly uploading data
+and publicizing it on Globus Search for easy accessibility and discovery. You can
+view the current list of projects by going to `petreldata.net<https://petreldata.net/nci-pilot1/>`_.
+
+By following the guide below, you will be able to use the NCI Pilot tools to discover,
+and access files from the projects you can see on the portal above.
+
 Installation
 ------------
 
-TODO: Link to or copy README
+These tools are available on Conda for Python 3.6, you can install them with the following:
+
+.. code-block:: bash
+
+    conda create -n pilot1-env -c conda-forge -c nickolaussaint pilot1-tools
+
+
+You can see the `Developer Guide Installation
+<https://github.com/globusonline/pilot1-tools/blob/master/docs/developer-guide.rst>`_ for more options.
 
 Uninstall
 ---------
 
-TODO: Link to or copy README
 
 .. code-block:: bash
 
-    pip uninstall pilot1-tools
+    conda uninstall pilot1-tools
 
 
 Updates
 -------
 
-TODO: Link to or copy README
+Updating uses the same command as installation. Conda will ask if you would
+like to upgrade to the latest version.
+
+.. code-block:: bash
+
+    conda install -c conda-forge -c nickolaussaint pilot1-tools
 
 Logging In
 ----------
@@ -176,5 +198,3 @@ Use ``pilot download <dataset>`` to download a dataset. Using the example above,
 
    pilot describe myfolder/example.tsv
    Saved example.tsv
-
-

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,9 +1,9 @@
 {% set name = "pilot1-tools" %}
-{% set version = "0.1.0.dev" %}
+{% set data = load_setup_py_data() %}
 
 package:
   name: "{{ name }}"
-  version: "{{ version }}"
+  version: {{ data.get('version') }}
 
 source:
   git_url: https://github.com/globusonline/{{ name }}
@@ -26,6 +26,9 @@ requirements:
     - pandas
     - click
     - tableschema
+    - configobj
+    - python-slugify
+    - requests-toolbelt
 
 test:
   imports:


### PR DESCRIPTION
These changes update the docs and apply some fixes to the conda build script. 

A newer dry-run dev package is now up on Conda here: https://anaconda.org/nickolaussaint/pilot1-tools

I think I've worked out the kinks with the newest build. All it should need is the newest PRs and it should be good to go. 

Edit: It still seems to be pulling in more files than it should. I think it may be expecting a MANIFEST.in, and since it's not getting it, conda just throws in everything. The initial build was 2 gigs, now half an MB after removing extraneous (my uncommitted testing stuff) files. 