### PR TITLE
Project fixes

### DIFF
--- a/pilot/commands/input_validation.py
+++ b/pilot/commands/input_validation.py
@@ -102,7 +102,7 @@ def validate_project_endpoint(v, ep):
 
 def validate_project_group(v, group):
     pc = commands.get_pilot_client()
-    valid_choices = list(pc.project.GROUPS.keys()) + ['None']
+    valid_choices = list(pc.project.GROUPS.keys()) + ['public']
     if group not in valid_choices:
         raise exc.PilotValidator('Group must be one of: '
                                  '{}'.format(', '.join(valid_choices)))

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -138,7 +138,7 @@ def add():
     project.update({'search_index': pc.project.DEFAULT_SEARCH_INDEX,
                     'resource_server': pc.project.DEFAULT_RESOURCE_SERVER})
     project['endpoint'] = pc.project.PROJECTS_ENDPOINT
-    project['group'] = pc.project.GROUPS.get(project['group'])
+    project['group'] = pc.project.GROUPS.get(project['group'], 'public')
     short_name = project.pop('short_name')
     project['base_path'] = os.path.join(
         pc.project.PROJECTS_PATH,

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -70,7 +70,7 @@ def project_command(ctx):
                 click.echo(fmt.format(' ', project))
 
 
-@project.command(help='Update stored list of projects.')
+@project_command.command(help='Update stored list of projects.')
 @click.option('--dry-run', is_flag=True, default=False)
 def update(dry_run):
     pc = commands.get_pilot_client()
@@ -87,7 +87,7 @@ def update(dry_run):
         click.secho(str(hce), fg='red')
 
 
-@project.command(name='set', help='Set your project')
+@project_command.command(name='set', help='Set your project')
 @click.argument('project', required=True)
 def set_command(project):
     pc = commands.get_pilot_client()
@@ -98,7 +98,7 @@ def set_command(project):
         click.secho(str(ve), fg='red')
 
 
-@project.command(help='Add a new project')
+@project_command.command(help='Add a new project')
 def add():
     pc = commands.get_pilot_client()
     order = ['title', 'short_name', 'description', 'group']
@@ -158,7 +158,7 @@ def add():
                 'this tool.'.format(project['title']), fg='green')
 
 
-@project.command(help='Print project details')
+@project_command.command(help='Print project details')
 @click.argument('project', required=False)
 def info(project=None):
     pc = commands.get_pilot_client()

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -142,7 +142,7 @@ def add():
     short_name = project.pop('short_name')
     project['base_path'] = os.path.join(
         pc.project.PROJECTS_PATH,
-        path_utils.slug_to_path(short_name)
+        short_name
     )
 
     click.secho('Updating global project list... ', nl=False)

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -217,7 +217,7 @@ def delete(project):
         return 1
     click.echo('Deleting Data...')
     ddata = globus_sdk.DeleteData(transfer_client, pinfo['endpoint'],
-                                  recursive=True)
+                                  recursive=True, notify_on_succeeded=False)
     ddata.add_item(project_base_path)
     transfer_client.submit_delete(ddata)
     click.echo('Deleting Search Records...')

--- a/pilot/commands/search/search_commands.py
+++ b/pilot/commands/search/search_commands.py
@@ -32,7 +32,7 @@ def search_by_project(project=None, custom_params=None):
     custom_params = custom_params or {}
     search_data.update(custom_params)
     sc = pc.get_search_client()
-    return sc.post_search(pc.get_index(), search_data).data
+    return sc.post_search(pc.get_index(project=project), search_data).data
 
 
 @click.command(name='list', help='List known records in Globus Search')


### PR DESCRIPTION
Fixes for #53 and a project decorator not being set correctly. The fix for #53 was due to the project not being explicitly passed when fetching the index, causing pilot to default on the 'current' project's search index.

Other fixes:

* Fixed bug when uploading data to project with 'public' access
* Fixed #54 
* Silenced transfer email when deleting project