### PR TITLE
Changed project decorator from 'project' to 'project_command'

### DIFF
--- a/pilot/commands/main.py
+++ b/pilot/commands/main.py
@@ -63,7 +63,7 @@ cli.add_command(auth_commands.logout)
 cli.add_command(auth_commands.whoami)
 cli.add_command(auth_commands.profile_command)
 
-cli.add_command(project.project)
+cli.add_command(project.project_command)
 
 cli.add_command(search_commands.list_command)
 cli.add_command(search_commands.describe)

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -46,7 +46,7 @@ ADD_PROJECT_QUERIES = {
 @click.group(name='project', help='Set or display project information',
              invoke_without_command=True)
 @click.pass_context
-def project(ctx):
+def project_command(ctx):
     pc = commands.get_pilot_client()
     if not pc.is_logged_in():
         click.echo('You are not logged in.')
@@ -184,7 +184,7 @@ def info(project=None):
     click.echo(info['description'])
 
 
-@project.command(help='Delete a project')
+@project_command.command(help='Delete a project')
 @click.argument('project', required=True)
 def delete(project):
     pc = commands.get_pilot_client()
@@ -229,7 +229,7 @@ def delete(project):
                 fg='green')
 
 
-@project.command(help='Edit items about your project')
+@project_command.command(help='Edit items about your project')
 @click.argument('project', required=False)
 def edit(project=None):
     pc = commands.get_pilot_client()
@@ -253,7 +253,7 @@ def edit(project=None):
     click.secho('Project "{}" has been updated'.format(project), fg='green')
 
 
-@project.command(help='Update the global list of projects')
+@project_command.command(help='Update the global list of projects')
 def push():
     pc = commands.get_pilot_client()
     pc.project.push()


### PR DESCRIPTION
There are still a mixture of functions referring to both `@project` and `@project_command`. There are some variables that use `project` which would technically overwrite the @project command, so I went ahead and switched everything to use `@project_command`. Using `@project` would probably be fine, but it's possible we could run into errors if we ever expected to call into that module multiple times during the lifetime of an invoked command (Maybe possible in testing). 