### PR TITLE
General analytics

### DIFF
--- a/pilot/analysis/__init__.py
+++ b/pilot/analysis/__init__.py
@@ -1,0 +1,23 @@
+import logging
+from pilot.analysis import tsv
+
+log = logging.getLogger(__name__)
+
+ANALYZE_MAP = {
+    'text/tab-separated-values': tsv.analyze_tsv,
+    'text/comma-separated-values': tsv.analyze_csv,
+}
+
+
+def analyze_dataframe(filename, mimetype=None, foreign_keys=None):
+    analyze_function = ANALYZE_MAP.get(mimetype, None)
+    if analyze_function is None:
+        log.debug('No analyzer for mimetype {}'.format(mimetype))
+        return {}
+
+    try:
+        return analyze_function(filename, foreign_keys=foreign_keys)
+    except Exception as e:
+        log.exception(e)
+        log.error('Failed to parse metadata.')
+    return {}

--- a/pilot/commands/auth/auth_commands.py
+++ b/pilot/commands/auth/auth_commands.py
@@ -89,7 +89,7 @@ def whoami():
     if not pc.is_logged_in():
         click.echo('You are not logged in.')
     else:
-        user_info = pc.profile.load_user_info() 
+        user_info = pc.profile.load_user_info()
         click.echo(user_info['name'])
         click.echo(user_info['preferred_username'])
 

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -6,7 +6,7 @@ from slugify import slugify
 import globus_sdk
 
 from pilot import commands, exc
-from pilot.commands import input_validation, path_utils, search
+from pilot.commands import input_validation, search
 
 log = logging.getLogger(__name__)
 

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -119,6 +119,7 @@ def scrape_metadata(dataframe, url, pilot_client, skip_analysis=True):
         },
         'files': gen_remote_file_manifest(dataframe, url, pilot_client,
                                           metadata=rfm_metadata,
+                                          mimetype=mimetype,
                                           skip_analysis=skip_analysis),
         'project_metadata': {
             'project-slug': pilot_client.project.current
@@ -277,12 +278,14 @@ def gen_dc_formats(metadata, formats):
 
 def gen_remote_file_manifest(filepath, url, pilot_client, metadata={},
                              algorithms=DEFAULT_HASH_ALGORITHMS,
+                             mimetype=None,
                              skip_analysis=True):
     rfm = metadata.copy()
     rfm.update({alg: compute_checksum(filepath, getattr(hashlib, alg)())
                 for alg in algorithms})
     fkeys = get_foreign_keys(pilot_client)
-    metadata = analyze_dataframe(filepath, fkeys) if not skip_analysis else {}
+    metadata = (analyze_dataframe(filepath, mimetype, fkeys)
+                if not skip_analysis else {})
     rfm.update({
         'filename': os.path.basename(filepath),
         'url': url,

--- a/pilot/version.py
+++ b/pilot/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.2.0.dev0'
+__version__ = '0.2.1.dev0'

--- a/tests/unit/test_analyze.py
+++ b/tests/unit/test_analyze.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 
 def test_analyze_dataframe(mixed_tsv):
-    ana = analyze_dataframe(mixed_tsv)
+    ana = analyze_dataframe(mixed_tsv, 'text/tab-separated-values')
     assert ana['numcols'] == 2
     assert ana['numrows'] == 99
     row1_keys = set(ana['field_definitions'][0].keys())
@@ -18,7 +18,7 @@ def test_analyze_dataframe(mixed_tsv):
 
 
 def test_preview_bytes(mixed_tsv):
-    ana = analyze_dataframe(mixed_tsv)
+    ana = analyze_dataframe(mixed_tsv, 'text/tab-separated-values')
     with open(mixed_tsv) as fp:
         preview_data = StringIO(fp.read(ana['previewbytes']))
     preview_df = pandas.read_csv(preview_data, sep='\t', encoding='utf8')
@@ -27,3 +27,7 @@ def test_preview_bytes(mixed_tsv):
     assert list(preview_df.columns) == list(normal_df.columns)
     assert preview_df.head(10).to_dict() == normal_df.head(10).to_dict()
     assert preview_df.head(11).to_dict() != normal_df.head(11).to_dict()
+
+
+def test_analyze_dataframe_with_unknown_mimetype(mixed_tsv):
+    assert analyze_dataframe(mixed_tsv, 'completely_unknown_mimetype') == {}


### PR DESCRIPTION
This adds a fix for #55 so pilot can upload arbitrary file types. Pilot won't necessarily analyze everything, but it now has a lookup table (lookup by mimetype) to determine what it should attempt to analyze, and what it should ignore (I played around a little with `import_module` for importing arbitrary analysis packages and running them, but that seemed to be overkill unless we want to allow users to have a flag or config that allows them to specify a function they want to run. For now, a simple lookup table should suit our needs just fine). 

Next up is getting images/pdfs/tsvs/csvs and raw text to display in the portal preview. 
