### PR TITLE
[WIP] Dynamic groups

### DIFF
--- a/pilot/commands/input_validation.py
+++ b/pilot/commands/input_validation.py
@@ -100,11 +100,10 @@ def validate_project_endpoint(v, ep):
 
 
 def validate_project_group(v, group):
-    pc = commands.get_pilot_client()
-    valid_choices = list(pc.project.GROUPS.keys()) + ['public']
-    if group not in valid_choices:
+    groups = v.queries['group']['groups']
+    if group not in groups:
         raise exc.PilotValidator('Group must be one of: '
-                                 '{}'.format(', '.join(valid_choices)))
+                                 '{}'.format(', '.join(groups)))
 
 
 def validate_project_path_unique(v, path):


### PR DESCRIPTION
Marked [WIP], due to still waiting on access to the groups api so we can fetch the master subgroups list from Globus instead of tracking a separate list. 

Globus groups are now stored and loaded from the master project
manifest. This will allow us to add groups without doing a
pull request, and lays the groundwork for automatically fetching
groups from Globus.
