### PR TITLE
Added small fix for fair-research-login upgrade

### DIFF
--- a/pilot/config.py
+++ b/pilot/config.py
@@ -2,6 +2,7 @@ import os
 import logging
 from configobj import ConfigObj
 from fair_research_login import ConfigParserTokenStorage
+from fair_research_login import version as frl_version
 
 from pilot.version import __version__
 
@@ -55,10 +56,14 @@ class Config():
                 int(tokens[tset]['expires_at_seconds'])
             rt = tokens[tset]['refresh_token']
             tokens[tset]['refresh_token'] = None if rt == 'None' else rt
-        return tokens
+        if frl_version.__version__ < '0.2.0.dev':
+            return tokens
+        return [tokens] if tokens else []
 
     def write_tokens(self, tokens):
         cfg = self.load()
+        if isinstance(tokens, list):
+            tokens = tokens[0]
         cfg['tokens'] = tokens
         cfg.write()
 


### PR DESCRIPTION
The big change in fair-research-login is switching to 'login-lists' to capture a users full login history. It turned out that the new storage mechanism we're using, configobj, does support storing lists of complex data, but getting it to do so is a little cumbersome. Although the specification lists information about `[[[__many__]]]` [sections](https://configobj.readthedocs.io/en/latest/configobj.html#repeated-sections) (lists of complex data), there doesn't seem to be documentation on storing data this way without defining a configspec. 

Since Pilot doesn't need to store more than one list of logins, these changes ensure it simply maintains a single one. It would be nice if native login supported this behavior as well, for times when storing multiple logins isn't necessary and the downstream project has trouble saving all the complex data. 