### PR TITLE
Moved upload functionality into Pilot Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 Below are major changes for each version Release. For detailed information,
 see the list of commits from the last version or use `git log`.
 
-### 0.4.1 - 2019-09-20
+### 0.4.2 - 2019-09-24
 
+ - Fixed exception in `project push` and `project edit` commands
+ - Fixed regression, added test for improper file versioning
+ - Fixed bug with version being reset when metadata changed but file didn't
+ - Fixed Dry-run to properly generate change stats
+ - Fixed search.files_modified returning None instead of False
+ - Fixed string formatting on some exceptions
  - Fixed conda git lfs build error by switching to local builds
  - Fixed puremagic and fair-research-login build dependencies
  - Fixed diff not working for changes in context information on update
@@ -27,6 +33,9 @@ see the list of commits from the last version or use `git log`.
  - Fixed extended mimetype detection not working for file uploads
  - Fixed backwards compatibility for old table schema fields on text files
 
+ - Added new docs for new client usage
+ - Added new pilot.upload SDK call which automatically registers/uploads file
+ - Added new pilot.register SDK call for analyzing/ingesting metadata
  - Added debugging when pliot falls back to default context
  - Added puremagic dependency for detecting mimetypes
  - Added doc to show how to call into the pilot client
@@ -46,6 +55,8 @@ see the list of commits from the last version or use `git log`.
 
  - Removed deprecated `whoami` command
  - Removed old required fields (or fixed bug if mimetype was undetermined)
+
+ - Renamed low level pilot.upload call to upload_globus()
 
 
 ### 0.3.0 - 2019-07-17

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -38,7 +38,6 @@ class PilotClient(NativeClient):
     *  :py:meth:`.get_globus_url`
     *  :py:meth:`.get_globus_app_url`
     *  :py:meth:`.get_portal_url`
-    *  :py:meth:`.get_globus_app_url`
     *  :py:meth:`.get_subject_url`
     *  :py:meth:`.ls`
     *  :py:meth:`.mkdir`
@@ -51,27 +50,28 @@ class PilotClient(NativeClient):
     ** Example **
     Login, upload, show various access methods, then delete.
 
-    from pilot.search import scrape_metadata, gen_gmeta
     pc = PilotClient()
+
+    # Setup the client (You can also do this with the CLI, both use the same
+    #                   credentials)
     pc.login()
     pc.project.current = 'foo'
-    pc.mkdir('bar')
-    pc.ls('bar')
 
-    metadata = scrape_metadata('moo.txt')
-    gmeta = gen_gmeta(pc.get_subject_url('bar/moo.txt'), ['public'], metadata)
-    pc.ingest_entry(gmeta)
+    # Create a directory, Upload a file to it
+    pc.mkdir('bar')
     pc.upload('moo.txt', 'bar')
 
+    # Get resources associated with the file
+    pc.ls('bar')
     pc.get_path('bar/moo.txt')
     pc.get_portal_url('bar/moo.txt')
     pc.get_globus_app_url('bar/moo.txt')
     pc.get_globus_http_url('bar/moo.txt')
     pc.download('bar/moo.txt')
 
+    # Delete the file
     pc.delete_entry('bar/moo.txt')
     pc.delete('bar/moo.txt')
-
     """
     DEFAULT_SCOPES = [
         'profile',

--- a/pilot/commands/project/project.py
+++ b/pilot/commands/project/project.py
@@ -264,7 +264,7 @@ def edit(project=None):
     new_info = iv.ask_all()
     info.update(new_info)
     pc.project.set_project(project, info)
-    pc.project.push()
+    pc.context.push()
     click.secho('Project "{}" has been updated'.format(project), fg='green')
 
 
@@ -272,6 +272,6 @@ def edit(project=None):
                          hidden=True)
 def push():
     pc = commands.get_pilot_client()
-    pc.project.push()
+    pc.context.push()
     click.secho('Global projects have been updated. Users will be notified '
                 'within 24 hours.', fg='green')

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -17,15 +17,6 @@ log = logging.getLogger(__name__)
 BIG_SIZE_WARNING = 2 ** 30
 
 
-def click_ingest_dataframe(gmeta):
-    pc = pilot.commands.get_pilot_client()
-    click.echo('Ingesting record into search...')
-    subject = gmeta['ingest_data']['gmeta'][0]['subject']
-    log.debug('Uploading Dataframe {}'.format(subject))
-    pc.ingest_entry(gmeta)
-    click.echo('Success!')
-
-
 @click.command(help='Upload dataframe to location on Globus and categorize it '
                     'in search')
 @click.argument('dataframe',

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -7,108 +7,14 @@ import globus_sdk
 import datetime
 import pilot
 import traceback
-from pilot.search import (scrape_metadata, update_metadata, gen_gmeta,
-                          files_modified, metadata_modified)
 from pilot.exc import (RequiredUploadFields, HTTPSClientException,
-                       InvalidField, AnalysisException, ExitCodes)
-from pilot import transfer_log
+                       InvalidField, ExitCodes)
 from jsonschema.exceptions import ValidationError
 
 log = logging.getLogger(__name__)
 
 # Warn people things will take a while when filesize exceeds 1GB
 BIG_SIZE_WARNING = 2 ** 30
-
-
-def click_prepare_dataframe(dataframe, destination, metadata, update,
-                            dry_run, verbose, no_analyze):
-    pc = pilot.commands.get_pilot_client()
-
-    if not destination:
-        dirs = pc.ls('')
-        click.echo('No Destination Provided. Please select one from the '
-                   'directory or "/" for root:\n{}'.format('\t '.join(dirs)))
-        return sys.exit(ExitCodes.NO_DESTINATION_PROVIDED)
-
-    try:
-        pc.ls(destination)
-    except globus_sdk.exc.TransferAPIError as tapie:
-        if tapie.code == 'ClientError.NotFound':
-            click.secho('Directory does not exist: "{}"'.format(destination),
-                        err=True, fg='yellow')
-            sys.exit(ExitCodes.DIRECTORY_DOES_NOT_EXIST)
-        else:
-            click.secho(tapie.message, err=True, bg='red')
-            sys.exit(ExitCodes.GLOBUS_TRANSFER_ERROR)
-
-    if metadata is not None:
-        with open(metadata) as mf_fh:
-            user_metadata = json.load(mf_fh)
-    else:
-        user_metadata = {}
-
-    short_path = os.path.join(destination, os.path.basename(dataframe))
-    prev_metadata = pc.get_search_entry(short_path)
-
-    url = pc.get_globus_http_url(short_path)
-
-    size_in_gb = os.stat(dataframe).st_size / BIG_SIZE_WARNING
-    if size_in_gb > 1:
-        click.secho('Generating hashes on {} ({:.2f}GB), this may take a '
-                    'while.'.format(dataframe, size_in_gb), fg='blue')
-    try:
-        new_metadata = scrape_metadata(dataframe, url, pc,
-                                       skip_analysis=no_analyze,
-                                       mimetype=user_metadata.get('mime_type'))
-    except AnalysisException as ae:
-        click.secho('Error analyzing {}, skipping...'.format(dataframe),
-                    fg='yellow')
-        if verbose:
-            traceback.print_exception(*ae.original_exc_info)
-        else:
-            click.secho('(Use --verbose to see full error)', fg='yellow')
-        new_metadata = scrape_metadata(dataframe, url, pc, skip_analysis=True)
-    log.debug('Finished scraping metadata and gathering analytics.')
-
-    try:
-        new_metadata = update_metadata(new_metadata, prev_metadata,
-                                       user_metadata)
-        subject = pc.get_subject_url(short_path)
-        gmeta = gen_gmeta(subject, [pc.get_group()], new_metadata)
-        log.debug('Metadata valid! Generated search entry. Ready to ingest!')
-    except (RequiredUploadFields, ValidationError, InvalidField) as e:
-        log.exception(e)
-        click.secho('Error Validating Metadata: {}'.format(e), fg='red')
-        sys.exit(ExitCodes.INVALID_METADATA)
-
-    if not metadata_modified(new_metadata, prev_metadata):
-        click.secho('Files and search entry are an exact match. No update '
-                    'necessary.', fg='green')
-        sys.exit(ExitCodes.SUCCESS)
-
-    if prev_metadata and not update and not dry_run:
-        last_updated = prev_metadata['dc']['dates'][-1]['date']
-        dt = datetime.datetime.strptime(last_updated, '%Y-%m-%dT%H:%M:%S.%fZ')
-        click.echo('Existing record found for {}, specify -u to update.\n'
-                   'Last updated: {: %A, %b %d, %Y}'
-                   ''.format(short_path, dt))
-        sys.exit(ExitCodes.RECORD_EXISTS)
-    if dry_run:
-        click.echo('Success! (Dry Run -- No changes made.)')
-        click.echo('Pre-existing record: {}'.format(
-            'yes' if prev_metadata else 'no'))
-        click.echo('Version: {}'.format(new_metadata['dc']['version']))
-        click.echo('Search Subject: {}\nURL: {}'.format(
-            subject, url
-        ))
-        if verbose:
-            click.echo('Ingesting the following data:')
-            click.echo(json.dumps(new_metadata, indent=2))
-        sys.exit(ExitCodes.SUCCESS)
-
-    nun = prev_metadata and not files_modified(new_metadata['files'],
-                                               prev_metadata['files'])
-    return {'gmeta': gmeta, 'no_update_needed': nun}
 
 
 def click_ingest_dataframe(gmeta):
@@ -118,44 +24,6 @@ def click_ingest_dataframe(gmeta):
     log.debug('Uploading Dataframe {}'.format(subject))
     pc.ingest_entry(gmeta)
     click.echo('Success!')
-
-
-def click_upload_dataframe(dataframe, destination, gcp=True):
-    pc = pilot.commands.get_pilot_client()
-    short_path = os.path.join(destination, os.path.basename(dataframe))
-    if gcp:
-        tc = pc.get_transfer_client()
-        tdata = globus_sdk.TransferData(
-            tc, pc.profile.load_option('local_endpoint'), pc.get_endpoint(),
-            label='{} Transfer'.format(pc.context.get_value('app_name')),
-            notify_on_succeeded=False,
-            sync_level='checksum',
-            encrypt_data=True)
-        tdata.add_item(dataframe, pc.get_path(short_path))
-        click.echo('Starting Transfer...')
-        transfer_result = tc.submit_transfer(tdata)
-        log.debug('Submitted Transfer')
-        tl = transfer_log.TransferLog()
-        tl.add_log(transfer_result, short_path)
-        click.echo('{}. You can check the status below: \n'
-                   'https://app.globus.org/activity/{}/overview\n'.format(
-                        transfer_result.get('message'),
-                        transfer_result.get('task_id'),
-                        )
-                   )
-    else:
-        url = pc.get_globus_http_url(short_path)
-        click.echo('Uploading data...')
-        response = pc.upload(dataframe, destination)
-        if response.status_code == 200:
-            click.echo('Upload Successful! URL is \n{}'.format(url))
-        else:
-            click.echo('Failed with status code: {}'.format(
-                response.status_code))
-            return
-    url = pc.get_portal_url(short_path)
-    if url:
-        click.echo('You can find your result here: {}'.format(url))
 
 
 @click.command(help='Upload dataframe to location on Globus and categorize it '
@@ -171,8 +39,6 @@ def click_upload_dataframe(dataframe, destination, gcp=True):
 @click.option('--gcp/--no-gcp', default=True,
               help='Use Globus Connect Personal to start a transfer instead '
                    'of uploading using direct HTTP')
-@click.option('--test', is_flag=True, default=False,
-              help='upload/ingest to test locations')
 @click.option('--dry-run', is_flag=True, default=False,
               help='Do checks and validation but do not upload/ingest. ')
 @click.option('--verbose', is_flag=True, default=False)
@@ -182,27 +48,49 @@ def click_upload_dataframe(dataframe, destination, gcp=True):
 #               help='Path to x label file')
 # @click.option('--y-labels', type=click.Path(),
 #               help='Path to y label file')
-def upload(dataframe, destination, metadata, gcp, update, test, dry_run,
+@click.pass_context
+def upload(ctx, dataframe, destination, metadata, gcp, update, dry_run,
            verbose, no_analyze):
     """
     Create a search entry and upload this file to the GCS Endpoint.
 
     # TODO: Fault tolerance for interrupted or failed file uploads (rollback)
     """
-    pc = pilot.commands.get_pilot_client()
-
-    if gcp and not pc.profile.load_option('local_endpoint'):
-        click.secho('No Local endpoint set, please set it with '
-                    '"pilot profile --local-endpoint"', fg='red')
-        sys.exit(ExitCodes.NO_LOCAL_ENDPOINT_SET)
-
-    data = click_prepare_dataframe(dataframe, destination, metadata,
-                                   update, dry_run, verbose, no_analyze)
-    click_ingest_dataframe(data['gmeta'])
-    if data['no_update_needed']:
-        click.echo('Dataframe is up-to-date, no upload needed')
-    else:
-        click_upload_dataframe(dataframe, destination, gcp)
+    user_metadata = {}
+    if metadata is not None:
+        with open(metadata) as mf_fh:
+            user_metadata = json.load(mf_fh)
+    try:
+        pc = pilot.commands.get_pilot_client()
+        pc.upload(dataframe, destination, metadata=user_metadata, globus=gcp,
+                  update=update, dry_run=dry_run, skip_analysis=no_analyze)
+    except pilot.exc.AnalysisException as ae:
+        click.secho('Error analyzing {}, skipping...'.format(dataframe),
+                    fg='yellow')
+        if verbose:
+            traceback.print_exception(*ae.original_exc_info)
+        else:
+            click.secho('(Use --verbose to see full error)', fg='yellow')
+        ctx.invoke(upload, dataframe=dataframe, destination=destination,
+                   metadata=metadata, gcp=gcp, update=update, dry_run=dry_run,
+                   verbose=verbose, no_analyze=True)
+    except (RequiredUploadFields, ValidationError, InvalidField) as e:
+        log.exception(e)
+        click.secho('Error Validating Metadata: {}'.format(e), fg='red')
+        sys.exit(ExitCodes.INVALID_METADATA)
+    except pilot.exc.RecordExists as re:
+        last_updated = re.previous_metadata['dc']['dates'][-1]['date']
+        dt = datetime.datetime.strptime(last_updated, '%Y-%m-%dT%H:%M:%S.%fZ')
+        click.echo('Existing record found for {}, specify -u to update.\n'
+                   'Last updated: {: %A, %b %d, %Y}'
+                   ''.format(os.path.basename(dataframe), dt))
+        sys.exit(re.CODE)
+    except pilot.exc.PilotCodeException as pce:
+        if verbose:
+            click.echo(pce.verbose_output)
+        fg = 'green' if pce.CODE == ExitCodes.SUCCESS else 'yellow'
+        click.secho(str(pce), err=True, fg=fg)
+        sys.exit(pce.CODE)
 
 
 @click.command(help='Register an existing dataframe in search', hidden=True)
@@ -224,9 +112,7 @@ def register(dataframe, destination, metadata, update, dry_run, verbose,
     """
     Create a search entry for a pre-existing file
     """
-    data = click_prepare_dataframe(dataframe, destination, metadata,
-                                   update, dry_run, verbose, no_analyze)
-    click_ingest_dataframe(data['gmeta'])
+    raise NotImplemented('Refactoring in progress!')
 
 
 @click.command(help='Download a file to your local directory.')

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -53,8 +53,14 @@ def upload(ctx, dataframe, destination, metadata, gcp, update, dry_run,
             user_metadata = json.load(mf_fh)
     try:
         pc = pilot.commands.get_pilot_client()
+        transport = 'globus' if gcp else 'http'
+        click.secho('Uploading {} using {}... '.format(dataframe, transport))
         pc.upload(dataframe, destination, metadata=user_metadata, globus=gcp,
                   update=update, dry_run=dry_run, skip_analysis=no_analyze)
+        click.secho('Success!', fg='green')
+        short_path = os.path.join(destination, os.path.basename(dataframe))
+        url = pc.get_portal_url(short_path)
+        click.echo('You can view your new record here: \n{}'.format(url))
     except pilot.exc.AnalysisException as ae:
         click.secho('Error analyzing {}, skipping...'.format(dataframe),
                     fg='yellow')

--- a/pilot/commands/transfer/transfer_commands.py
+++ b/pilot/commands/transfer/transfer_commands.py
@@ -7,6 +7,7 @@ import globus_sdk
 import datetime
 import pilot
 import traceback
+import contextlib
 from pilot.exc import (RequiredUploadFields, HTTPSClientException,
                        InvalidField, ExitCodes)
 from jsonschema.exceptions import ValidationError
@@ -52,15 +53,19 @@ def upload(ctx, dataframe, destination, metadata, gcp, update, dry_run,
         with open(metadata) as mf_fh:
             user_metadata = json.load(mf_fh)
     try:
-        pc = pilot.commands.get_pilot_client()
-        transport = 'globus' if gcp else 'http'
-        click.secho('Uploading {} using {}... '.format(dataframe, transport))
-        pc.upload(dataframe, destination, metadata=user_metadata, globus=gcp,
-                  update=update, dry_run=dry_run, skip_analysis=no_analyze)
-        click.secho('Success!', fg='green')
-        short_path = os.path.join(destination, os.path.basename(dataframe))
-        url = pc.get_portal_url(short_path)
-        click.echo('You can view your new record here: \n{}'.format(url))
+        with pilot_code_handler(dataframe, destination, verbose):
+            pc = pilot.commands.get_pilot_client()
+
+            transport = 'globus' if gcp else 'http'
+            click.secho('Uploading {} using {}... '.format(dataframe,
+                                                           transport))
+            pc.upload(dataframe, destination, metadata=user_metadata,
+                      globus=gcp, update=update, dry_run=dry_run,
+                      skip_analysis=no_analyze)
+            click.secho('Success!', fg='green')
+            short_path = os.path.join(destination, os.path.basename(dataframe))
+            url = pc.get_portal_url(short_path)
+            click.echo('You can view your new record here: \n{}'.format(url))
     except pilot.exc.AnalysisException as ae:
         click.secho('Error analyzing {}, skipping...'.format(dataframe),
                     fg='yellow')
@@ -71,23 +76,6 @@ def upload(ctx, dataframe, destination, metadata, gcp, update, dry_run,
         ctx.invoke(upload, dataframe=dataframe, destination=destination,
                    metadata=metadata, gcp=gcp, update=update, dry_run=dry_run,
                    verbose=verbose, no_analyze=True)
-    except (RequiredUploadFields, ValidationError, InvalidField) as e:
-        log.exception(e)
-        click.secho('Error Validating Metadata: {}'.format(e), fg='red')
-        sys.exit(ExitCodes.INVALID_METADATA)
-    except pilot.exc.RecordExists as re:
-        last_updated = re.previous_metadata['dc']['dates'][-1]['date']
-        dt = datetime.datetime.strptime(last_updated, '%Y-%m-%dT%H:%M:%S.%fZ')
-        click.echo('Existing record found for {}, specify -u to update.\n'
-                   'Last updated: {: %A, %b %d, %Y}'
-                   ''.format(os.path.basename(dataframe), dt))
-        sys.exit(re.CODE)
-    except pilot.exc.PilotCodeException as pce:
-        if verbose:
-            click.echo(pce.verbose_output)
-        fg = 'green' if pce.CODE == ExitCodes.SUCCESS else 'yellow'
-        click.secho(str(pce), err=True, fg=fg)
-        sys.exit(pce.CODE)
 
 
 @click.command(help='Register an existing dataframe in search', hidden=True)
@@ -109,7 +97,76 @@ def register(dataframe, destination, metadata, update, dry_run, verbose,
     """
     Create a search entry for a pre-existing file
     """
-    raise NotImplemented('Refactoring in progress!')
+    user_metadata = {}
+    if metadata is not None:
+        with open(metadata) as mf_fh:
+            user_metadata = json.load(mf_fh)
+    short_path = os.path.join(destination, os.path.basename(dataframe))
+    with pilot_code_handler(short_path, verbose):
+        pc = pilot.commands.get_pilot_client()
+        click.secho('Registering {}... '.format(dataframe))
+        pc.register(dataframe, destination, metadata=user_metadata,
+                    update=update, dry_run=dry_run, skip_analysis=no_analyze)
+        click.secho('Success!', fg='green')
+        url = pc.get_portal_url(short_path)
+        click.echo('You can view your new record here: \n{}'.format(url))
+
+
+@contextlib.contextmanager
+def pilot_code_handler(dataframe, destination, verbose):
+    """
+    Handle exceptions for a `pc.register` or `pc.upload` call. If exceptions
+    happen, this handler will cleanly catch the exception and print click
+    output for the result. Only code exceptions are caught, all other
+    exceptions fall through.
+    ** parameters **
+      ``short_name`` (*string*) the short-hard representation of the relative
+      path on the remote endpoint
+      ``verbose`` (*bool*) print verbose output
+    """
+    try:
+        pc = pilot.commands.get_pilot_client()
+        if not destination:
+            dirs = [n for n, d in pc.ls('', extended=True).items()
+                    if d['type'] == 'dir']
+            raise pilot.exc.NoDestinationProvided(fmt=[dirs])
+        yield
+    except (RequiredUploadFields, ValidationError, InvalidField) as e:
+        log.exception(e)
+        click.secho('Error Validating Metadata: {}'.format(e), fg='red')
+        sys.exit(ExitCodes.INVALID_METADATA)
+    except pilot.exc.RecordExists as re:
+        last_updated = re.previous_metadata['dc']['dates'][-1]['date']
+        dt = datetime.datetime.strptime(last_updated, '%Y-%m-%dT%H:%M:%S.%fZ')
+        short_path = os.path.join(destination, os.path.basename(dataframe))
+        click.echo('Existing record found for {}, specify -u to update.\n'
+                   'Last updated: {: %A, %b %d, %Y}'
+                   ''.format(short_path, dt))
+        sys.exit(re.CODE)
+    except pilot.exc.DryRun as dr:
+        pc = pilot.commands.get_pilot_client()
+        short_path = os.path.join(destination, os.path.basename(dataframe))
+        stats = dr.stats
+        stats.update({'subject': pc.get_subject_url(short_path),
+                      'url': pc.get_globus_http_url(short_path)})
+        click.secho('Success! (Dry Run -- No changes made.)', fg='green')
+        click.echo('Pre-existing record: {record_exists}\n'
+                   'Files Modified: {files_modified}\n'
+                   'Metadata Modified: {metadata_modified}\n'
+                   'Version: {version} (Would be updated to {new_version})\n'
+                   'Search Subject: {subject}\n'
+                   'URL: {url}\n'
+                   .format(**stats)
+                   )
+        if verbose:
+            _, metadata = dr.verbose_output
+            click.echo(json.dumps(metadata, indent=2))
+    except pilot.exc.PilotCodeException as pce:
+        if verbose:
+            click.echo(pce.verbose_output)
+        fg = 'green' if pce.CODE == ExitCodes.SUCCESS else 'yellow'
+        click.secho(str(pce), err=True, fg=fg)
+        sys.exit(pce.CODE)
 
 
 @click.command(help='Download a file to your local directory.')

--- a/pilot/context.py
+++ b/pilot/context.py
@@ -12,7 +12,7 @@ DEFAULT_PROJECTS_CACHE_TIMEOUT = 60 * 60 * 24
 DEFAULT_PILOT_CONTEXT = {
     'client_id': 'e4d82438-00df-4dbd-ab90-b6258933c335',
     'app_name': 'NCI Pilot 1 Dataframe Manager',
-    'manifest_subject': 'globus://pilot1-tools-project-manifest-v2.json',
+    'manifest_subject': 'globus://project-manifest.json',
     'manifest_index': '889729e8-d101-417d-9817-fa9d964fdbc9',
     'scopes': [
         'profile',

--- a/pilot/exc.py
+++ b/pilot/exc.py
@@ -57,7 +57,7 @@ class PilotCodeException(PilotClientException):
         self.message = message or self.MESSAGE
         self.fmt = fmt
         if fmt:
-            self.message = self.message.format(fmt)
+            self.message = self.message.format(*fmt)
         self.verbose = verbose
         self.verbose_output = ''
 
@@ -96,8 +96,8 @@ class RecordExists(PilotCodeException):
     MESSAGE = '"{}": Record Exists, extra confirmation needed to overwrite.'
     CODE = ExitCodes.RECORD_EXISTS
 
-    def __init__(self, previous_metadata, verbose=False):
-        super().__init__(verbose=verbose)
+    def __init__(self, previous_metadata, fmt=None, verbose=False):
+        super().__init__(verbose=verbose, fmt=fmt)
         self.previous_metadata = previous_metadata
 
 

--- a/pilot/exc.py
+++ b/pilot/exc.py
@@ -38,6 +38,86 @@ class PilotValidator(PilotClientException):
         return self.message
 
 
+class PilotCodeException(PilotClientException):
+    """Pilot Code Exceptions are a general class for any exception that might
+    be thrown during the execution of a pilot command. The main difference from
+    regular exceptions is a CODE, which must correspond to exc.ExitCodes, which
+    is the integer which will be passed to sys.exit(). This is solely to
+    facilitate bash scripting, so someone can check the exit code of a command
+    and have enough context to make a decision with that information.
+
+    Calling str(pce) on these exceptions must yield a user readable error,
+    where repr(pce) might also yield the exit code.
+    """
+    MESSAGE = 'Unknown Error'
+    CODE = ExitCodes.UNCAUGHT_EXCEPTION
+
+    def __init__(self, message=None, fmt=None, verbose=False):
+        super().__init__()
+        self.message = message or self.MESSAGE
+        self.fmt = fmt
+        if fmt:
+            self.message = self.message.format(fmt)
+        self.verbose = verbose
+        self.verbose_output = ''
+
+    def __str__(self):
+        return '{}\n{}'.format(
+            self.message, self.verbose_output if self.verbose else '')
+
+    def __repr__(self):
+        return '({}) {}\n{}'.format(
+            self.CODE.name, self.message,
+            self.verbose_output if self.verbose else '')
+
+
+class NoDestinationProvided(PilotCodeException):
+    MESSAGE = ('No Destination Provided. Please select one from the '
+               'directory or "/" for root:\n{}')
+    CODE = ExitCodes.NO_DESTINATION_PROVIDED
+
+
+class DirectoryDoesNotExist(PilotCodeException):
+    MESSAGE = 'Directory does not exist: "{}"'
+    CODE = ExitCodes.DIRECTORY_DOES_NOT_EXIST
+
+
+class GlobusTransferError(PilotCodeException):
+    MESSAGE = '{}'
+    CODE = ExitCodes.GLOBUS_TRANSFER_ERROR
+
+
+class NoChangesNeeded(PilotCodeException):
+    MESSAGE = '"{}": Files and search entry are an exact match.'
+    CODE = ExitCodes.SUCCESS
+
+
+class RecordExists(PilotCodeException):
+    MESSAGE = '"{}": Record Exists, extra confirmation needed to overwrite.'
+    CODE = ExitCodes.RECORD_EXISTS
+
+    def __init__(self, previous_metadata, verbose=False):
+        super().__init__(verbose=verbose)
+        self.previous_metadata = previous_metadata
+
+
+class DryRun(PilotCodeException):
+    MESSAGE = 'Dry run: No changes applied'
+    CODE = ExitCodes.SUCCESS
+
+    def __init__(self, previous_metadata, new_metadata, verbose=False):
+        super().__init__(verbose=verbose)
+        self.message = self.MESSAGE
+        self.previous_metadata = previous_metadata
+        self.new_metadata = new_metadata
+        self.verbose_output = self.new_metadata
+
+
+class NoLocalEndpointSet(PilotCodeException):
+    MESSAGE = 'No Local endpoint set'
+    CODE = ExitCodes.NO_LOCAL_ENDPOINT_SET
+
+
 class RequiredUploadFields(PilotClientException):
 
     def __init__(self, message, fields, *args, **kwargs):

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -200,12 +200,15 @@ def metadata_modified(new_metadata, old_metadata):
     zipped_dates = zip(new_metadata['dc']['dates'], old_dates)
     date_types_match = [nm['dateType'] == om['dateType']
                         for nm, om in zipped_dates]
-    return not all([
+    matches = [
         all(general_fields_match),
         all(dc_fields_match),
         date_entry_lengths_eq,
         all(date_types_match)
-    ])
+    ]
+    log.debug('Metadata comparison: files/metadata: {}, dc: {}, '
+              'date entries: {}, date types: {}'.format(*matches))
+    return not all(matches)
 
 
 def update_dc_version(metadata):

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -178,6 +178,7 @@ def files_modified(manifest1, manifest2):
         man1dict, man2dict = man1.get(url_key), man2.get(url_key)
         if any([man1dict.get(f) != man2dict.get(f) for f in fields]):
             return True
+    return False
 
 
 def metadata_modified(new_metadata, old_metadata):

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -211,24 +211,27 @@ def metadata_modified(new_metadata, old_metadata):
     return not all(matches)
 
 
-def update_dc_version(metadata):
-    version = int(metadata['dc']['version'])
-    metadata['dc']['version'] = str(version + 1)
-    metadata['dc']['dates'].append({
+def update_dc_version(new_metadata, old_metadata):
+    version = int(old_metadata['dc']['version'])
+    new_metadata['dc']['version'] = str(version + 1)
+    new_metadata['dc']['dates'].append({
         'dateType': 'Updated',
         'date': get_formatted_date()
     })
+    return new_metadata['dc']['version']
 
 
 def update_metadata(scraped_metadata, prev_metadata, user_metadata):
     if prev_metadata:
+        log.debug('Previous metadata detected!')
         metadata = copy.deepcopy(scraped_metadata or {})
 
         files_updated = files_modified(scraped_metadata.get('files'),
-                                       metadata.get('files'))
+                                       prev_metadata.get('files'))
         if files_updated:
             # If files have been modified, don't carryover metadata fields
-            update_dc_version(metadata)
+            v = update_dc_version(metadata, prev_metadata)
+            log.debug('Updated version to {}'.format(v))
         metadata['files'] = carryover_old_file_metadata(
             scraped_metadata.get('files'),
             prev_metadata.get('files')

--- a/pilot/search.py
+++ b/pilot/search.py
@@ -212,26 +212,31 @@ def metadata_modified(new_metadata, old_metadata):
 
 
 def update_dc_version(new_metadata, old_metadata):
+    """
+    Compare new metadata with old metadata, and derive a new version number.
+    If files have changed in the old metadata, returns new metadata with
+    bumped version. Otherwise, simply carries over the old metadata version
+    number.
+    """
+    files_updated = files_modified(new_metadata.get('files'),
+                                   old_metadata.get('files'))
     version = int(old_metadata['dc']['version'])
-    new_metadata['dc']['version'] = str(version + 1)
-    new_metadata['dc']['dates'].append({
-        'dateType': 'Updated',
-        'date': get_formatted_date()
-    })
-    return new_metadata['dc']['version']
+    if files_updated:
+        new_metadata['dc']['version'] = str(version + 1)
+        new_metadata['dc']['dates'].append({
+            'dateType': 'Updated',
+            'date': get_formatted_date()
+        })
+    else:
+        new_metadata['dc']['version'] = old_metadata['dc']['version']
+    return new_metadata
 
 
 def update_metadata(scraped_metadata, prev_metadata, user_metadata):
     if prev_metadata:
         log.debug('Previous metadata detected!')
         metadata = copy.deepcopy(scraped_metadata or {})
-
-        files_updated = files_modified(scraped_metadata.get('files'),
-                                       prev_metadata.get('files'))
-        if files_updated:
-            # If files have been modified, don't carryover metadata fields
-            v = update_dc_version(metadata, prev_metadata)
-            log.debug('Updated version to {}'.format(v))
+        metadata = update_dc_version(metadata, prev_metadata)
         metadata['files'] = carryover_old_file_metadata(
             scraped_metadata.get('files'),
             prev_metadata.get('files')

--- a/pilot/version.py
+++ b/pilot/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.4.1.dev0'
+__version__ = '0.4.1.dev1'

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ from .mocks import (MemoryStorage, MOCK_TOKEN_SET, GlobusTransferTaskResponse,
                     ANALYSIS_FILE_BASE_DIR, SCHEMA_FILE_BASE_DIR,
                     MOCK_PROFILE, MOCK_PROJECTS, MOCK_CONTEXT)
 
-from pilot import client, config, commands
+from pilot import client, config, commands, transfer_log
 
 
 @pytest.fixture
@@ -135,6 +135,13 @@ def mock_cli_basic(monkeypatch, mock_config, mock_projects):
 
 
 @pytest.fixture
+def mock_transfer_log(monkeypatch):
+    add_log = Mock()
+    monkeypatch.setattr(transfer_log.TransferLog, 'add_log', add_log)
+    return add_log
+
+
+@pytest.fixture
 def mock_cli(mock_cli_basic, mock_transfer_client, mock_profile):
     """
     Returns a mock logged in pilot client. Storage is mocked with a custom
@@ -142,7 +149,11 @@ def mock_cli(mock_cli_basic, mock_transfer_client, mock_profile):
     All methods that reach out to remote resources are mocked, you need to
     re-mock them to return the test data you want.
     """
-    mock_cli_basic.upload = Mock()
+    # mock_cli_basic.upload_http = Mock()
+    # mock_cli_basic.upload_globus = Mock()
+    # mock_cli_basic.download_http = Mock()
+    # mock_cli_basic.download_globus = Mock()
+    mock_cli_basic.transfer_file = Mock()
     mock_cli_basic.login = Mock()
     mock_cli_basic.logout = Mock()
     mock_cli_basic.ingest_entry = Mock()
@@ -154,4 +165,5 @@ def mock_cli(mock_cli_basic, mock_transfer_client, mock_profile):
     mock_cli_basic.get_search_client = Mock()
     mock_cli_basic.get_transfer_client = Mock()
     mock_cli_basic.get_auth_client = Mock()
+    mock_cli_basic.get_http_client = Mock()
     return mock_cli_basic

--- a/tests/unit/test_client_data_utils.py
+++ b/tests/unit/test_client_data_utils.py
@@ -74,7 +74,7 @@ def test_ls(monkeypatch, mock_cli_basic):
 def test_upload_http(monkeypatch, mixed_tsv, mock_cli_basic):
     put = Mock()
     monkeypatch.setattr(globus_clients.HTTPFileClient, 'put', put)
-    mock_cli_basic.upload('a.tsv', 'destination')
+    mock_cli_basic.upload_http('a.tsv', 'destination')
     assert put.called
     assert put.call_args == call('/foo_folder/destination/a.tsv',
                                  filename='a.tsv')

--- a/tests/unit/test_command_transfer.py
+++ b/tests/unit/test_command_transfer.py
@@ -27,10 +27,13 @@ def test_upload(mock_cli, monkeypatch):
 
 
 def test_upload_without_destination(mock_cli):
-    mock_cli.ls.return_value = ['foo', 'bar']
+    mock_cli.ls.return_value = {'foo': {'type': 'dir'},
+                                'bar': {'type': 'file'}}
     result = CliRunner().invoke(upload, [EMPTY_TEST_FILE])
     assert result.exit_code == ExitCodes.NO_DESTINATION_PROVIDED
     assert 'No Destination Provided' in result.output
+    assert 'foo' in result.output
+    assert 'bar' not in result.output
 
 
 def test_upload_to_nonexistant_dir(mock_cli, mock_transfer_error):

--- a/tests/unit/test_command_transfer.py
+++ b/tests/unit/test_command_transfer.py
@@ -98,7 +98,7 @@ def test_upload_dry_run(mock_cli):
     assert 'text/plain' in result.output
 
 
-def test_dataframe_up_to_date(mock_cli):
+def test_dataframe_up_to_date(mock_cli, mock_transfer_log):
     with open(EMTPY_TEST_FILE_META) as f:
         meta = json.load(f)
     mock_cli.get_search_entry.return_value = meta
@@ -116,11 +116,9 @@ def test_upload_local_endpoint_not_set(mock_cli, mock_profile):
     assert result.exit_code == ExitCodes.NO_LOCAL_ENDPOINT_SET
 
 
-def test_upload_gcp_log(mock_cli, monkeypatch):
-    add_log = Mock()
-    monkeypatch.setattr(transfer_log.TransferLog, 'add_log', add_log)
+def test_upload_gcp_log(mock_cli, mock_transfer_log):
     mock_cli.get_search_entry.return_value = {}
     mock_cli.get_transfer_client().submit_transfer.return_value = {}
     result = CliRunner().invoke(upload, [EMPTY_TEST_FILE, 'my_folder'])
     assert result.exit_code == 0
-    assert add_log.called
+    assert mock_transfer_log.called

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -45,3 +45,20 @@ def test_update_metadata_prev_record(mock_cli, mock_profile):
     meta = update_metadata(new, old, {})
     assert meta['dc']['creators'][0]['creatorName'] == 'Curie, Marie'
     assert meta['files'] == new['files'] == old['files']
+
+
+def test_update_file_version(mock_cli, mock_profile):
+
+    ver_one = scrape_metadata(MIXED_FILE, 'globus://foo.com', mock_cli)
+    ver_two = scrape_metadata(NUMBERS_FILE, 'globus://foo.com', mock_cli)
+    assert ver_one['dc']['version'] == '1'
+    assert ver_two['dc']['version'] == '1'
+    # Pretend 'NUMBERS_FILE' is an updated version of MIXED_FILE
+    updated = update_metadata(ver_two, ver_one, {})
+    assert updated['dc']['version'] == '2'
+    # Pretend we switched back
+    updated_3 = update_metadata(ver_one, updated, {})
+    assert updated_3['dc']['version'] == '3'
+    # Check re-updating does not bump version
+    updated_3 = update_metadata(ver_one, updated, {})
+    assert updated_3['dc']['version'] == '3'


### PR DESCRIPTION
Moved all functionality from doing a `pilot upload foo.txt /` into the Pilot Client. It's now possible to do the same thing with: 
```
from pilot.client import PilotClient
pc = PilotClient()
pc.upload('foo.txt', '/')
```
Arguments are very similar to the CLI command, and allow passing a variety of arguments (update=True, dry_run=True, etc). Errors are handled by exceptions, all of which match the errors that are produced by the CLI. An example is here:
```
from pilot import client, exc
pc = client.PilotClient()
try:
    pc.upload('foo.txt', '/', dry_run=True)
except exc.DryRun as dr:
    print(dr)
    print(dr.stats)
    print(dr.CODE)
    if dr.stats['record_exists'] is False:
        pc.upload('foo.txt', '/')
except exc.PilotCodeException as pce:
    # Catch all other standard upload exceptions
    print(pce)
print('Done!')
```