### PR TITLE
Added exalearn script to `scripts`.

### DIFF
--- a/scripts/exalearn_tomogan_fix.py
+++ b/scripts/exalearn_tomogan_fix.py
@@ -1,0 +1,24 @@
+from pilot.client import PilotClient
+from pilot.search import gen_gmeta
+
+PROJECT = 'tomogan'
+pc = PilotClient()
+pc.project.current = PROJECT
+
+tomogan_entries = pc.list_entries('', relative=False)
+
+for entry in tomogan_entries:
+    entry['content'][0]['dc']['creators'] = [
+            {'creatorName': 'Zhengchun Liu'},
+            {'creatorName': 'Tekin Bicer'},
+            {'creatorName': 'Raj Kettimuthu'},
+            {'creatorName': 'Ian Foster'},
+        ]
+    entry['content'][0]['dc']['publisher'] = 'Argonne'
+
+    is_simulation = entry['content'][0]['project_metadata']['sample'] == 'simulation'
+    exalearn_group = '6a60cf30-676a-11e9-8b34-0e4a32f5e3b8'
+    visible_to = [exalearn_group] if is_simulation else ['public']
+
+    gmeta = gen_gmeta(entry['subject'], visible_to, entry['content'][0])
+    pc.ingest_entry(gmeta)


### PR DESCRIPTION
This was a simple script to update metadata on the `exalearn` index, runnable on version 0.4.1 of pilot tools. This is probably a good replacement for the "exalearn" branch, as that code is based on a very old version of the pilot codebase. 

Runnable with:
`pilot context set exalearn`
`python scripts/exalearn_tomogan_fix.py`