### PR TITLE
Added instructions for setting encodings on a user's system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,28 @@ You can see the `Developer Guide Installation
 <https://github.com/globusonline/pilot1-tools/blob/master/docs/developer-guide.rst>`_ for more options.
 
 
+Setting Your Local
+^^^^^^^^^^^^^^^^^^
+
+The first time you run `pilot`, you may encounter an error an error like the one below:
+
+```
+RuntimeError: Click will abort further execution because Python 3 was
+  configured to use ASCII as encoding for the environment.
+```
+
+This can happen if on systems with custom configured UTF-8 settings. You should
+see a list of encodings your system supports, simply choose one and set it.
+For example:
+
+```
+export LC_ALL=en_US.utf-8
+export LANG=en_US.utf-8
+```
+
+Replace ``en_US.utf-8`` with an encoding your system supports.
+
+
 Quick Start
 -----------
 


### PR DESCRIPTION
Click may raise a nasty error if it doesn't find an encoding it
likes. This tells users how to fix the issue.