### PR TITLE
The 'list' command now supports the path argument and lists directories

### DIFF
--- a/pilot/commands/search/search_commands.py
+++ b/pilot/commands/search/search_commands.py
@@ -63,11 +63,12 @@ def get_location_info(entry):
 
 
 @click.command(name='list', help='List known records in Globus Search')
+@click.argument('path', type=click.Path(), required=False, default='')
 @click.option('--json/--no-json', 'output_json', default=False,
               help='Output as JSON.')
 @click.option('--limit', type=int, default=100,
               help='Limit returned results to the number provided')
-def list_command(output_json, limit):
+def list_command(path, output_json, limit):
     # Should require login if there are publicly visible records
     pc = commands.get_pilot_client()
     project = pc.project.current
@@ -75,14 +76,17 @@ def list_command(output_json, limit):
     if output_json:
         click.echo(json.dumps(search_results, indent=4))
         return
+    path_sub = pc.get_subject_url(path)
+    curated_results = [r for r in search_results['gmeta']
+                       if path_sub in r['subject']]
 
     results = 'Showing {}/{} of total results for "{}"'.format(
-        search_results['count'], search_results['total'], project)
+        len(curated_results), search_results['total'], project)
     items = ['title', 'data', 'dataframe', 'rows', 'columns', 'size']
     titles = get_titles(items) + ['Path']
     fmt = '{:21.20}{:11.10}{:10.9}{:7.6}{:7.6}{:7.6}{}'
-    output = [results, fmt.format(*titles)]
-    for result in search_results['gmeta']:
+    output = []
+    for result in curated_results:
         # If this path refers to a result in a different base location, skip
         # it, it isn't part of this project
         if pc.get_path('') not in result['subject']:
@@ -94,7 +98,22 @@ def list_command(output_json, limit):
         parsed = [str(p) for p in parsed]
 
         output.append(fmt.format(*parsed))
-    click.echo('\n'.join(output))
+    if not output:
+        click.secho('No results to display for "{}"'.format(path or '/'),
+                    fg='yellow')
+    else:
+        output = [results, fmt.format(*titles)] + output
+        click.echo('\n'.join(output))
+
+    log.debug("GOT HERE")
+    result_names = [os.path.basename(r['subject']) for r in curated_results]
+    path_info = pc.ls(path, extended=True)
+    dirs = [name for name, info in path_info.items()
+            if info['type'] == 'dir' and name not in result_names]
+    if dirs:
+        click.echo('\nDirectories:\n\t{}'.format('\n\t'.join(dirs)))
+    else:
+        click.echo('\nNo Directories in {}'.format(path or '/'))
 
 
 @click.command(help='Output info about a dataset')

--- a/tests/unit/test_command_search.py
+++ b/tests/unit/test_command_search.py
@@ -9,6 +9,7 @@ def test_list_command(monkeypatch, mock_cli, mock_search_results):
     globus_response.data = mock_search_results
     sc.post_search.return_value = globus_response
     mock_cli.get_search_client = Mock(return_value=sc)
+    mock_cli.ls.return_value = {}
     assert sc.post_search().data == mock_search_results
 
     runner = CliRunner()


### PR DESCRIPTION
One of the items in #103 
Example output:
```
(pilot) Firefly:pilot1-tools nick$ pilot list
Showing 5/5 of total results for "nick-testing"
Title                Data       Dataframe Rows   Column Size   Path
A001_Aerogel_1mm_att                                    32 M   A001_Aerogel_1mm_att6_Lq0_001_0001-1000
C017_Latex67nm_conc_                                    18 M   C017_Latex67nm_conc_att0_Lq0_001_0001-10000
B390_Dynamic_SMB_F_B                                    38 K   B390_Dynamic_SMB_F_BR2_Homo_Strain2.04mm_Ampl0.900mm_att0_Lq0_001_0001-5000
/Users/nick/globus/a                                    23 M   A001_Aerogel_1mm_att3_Lq0_001_0001-1000
meta.yaml                                               959    stuff/meta.yaml

Directories:
	bar
	stuff
```
- - - -
```
(pilot) Firefly:pilot1-tools nick$ pilot list stuff
Showing 1/5 of total results for "nick-testing"
Title                Data       Dataframe Rows   Column Size   Path
meta.yaml                                               959    stuff/meta.yaml

Directories:
	hello
```
- - - -
```
(pilot) Firefly:pilot1-tools nick$ pilot list stuff/hello
No results to display for "stuff/hello"

No Directories in stuff/hello
```

