### PR TITLE
basic image descriptive metadata

### DIFF
--- a/pilot/analysis/__init__.py
+++ b/pilot/analysis/__init__.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 from pilot import exc
-from pilot.analysis import mimetypes, pandas as pandalyze
+from pilot.analysis import mimetypes, pandas as pandalyze, image as imaginalyze
 
 log = logging.getLogger(__name__)
 
@@ -11,7 +11,9 @@ ANALYZE_MAP = {
     'application/x-hdf': pandalyze.analyze_hdf,
     'application/x-parquet': pandalyze.analyze_parquet,
     'application/x-feather': pandalyze.analyze_feather,
-}
+    'image/jpeg': imaginalyze.analyze_image,
+    'image/png': imaginalyze.analyze_image,
+    }
 
 
 def analyze_dataframe(filename, mimetype=None, foreign_keys=None):

--- a/pilot/analysis/image.py
+++ b/pilot/analysis/image.py
@@ -1,0 +1,13 @@
+import logging
+from wand.image import Image
+
+def analyze_image(filename, foreign_keys=None):
+    img = Image(filename=filename)
+    image_metadata = {
+        'name': 'Image Metadata',
+        'width': img.width,
+        'height': img.height,
+        'colorspace': img.colorspace,
+        'format': img.format,
+        }
+    return image_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ configobj
 python-slugify
 requests-toolbelt
 puremagic
+Wand


### PR DESCRIPTION
Minimal functioning image metadata extraction.

@NickolausDS not sure if this should be merged, since the metadata is showing up under `field_metadata`. That may confuse the portal (or may not). We'll need to decide if want to have different names for metadata for different file classes. Tables and images will probably cover a lot, though.

```
  "files": [
    {
      "sha256": "073a79185d8b77480e85617c8c2e2853e3d301e2af00bd9772bca6607715e239",
      "md5": "1fb7ae66ad119d178ad4f87289041084",
      "filename": "identifier-guidelines.png",
      "url": "https://ebf55996-33bf-11e9-9fa4-0a06afd4a22e.e.globus.org/projects/mshukla-test3/identifier-guidelines.png",
      "field_metadata": {
        "name": "Image Metadata",
        "width": 1460,
        "height": 696,
        "colorspace": "srgb",
        "format": "PNG"
      },
      "mime_type": "image/png",
      "length": 220923
    }
  ],
```