### PR TITLE
Added get_short_path() to address fundamental problem with Pilot scripting

### DIFF
--- a/pilot/client.py
+++ b/pilot/client.py
@@ -873,6 +873,7 @@ class PilotClient(NativeClient):
             subject, prev_candidates, precise=False)
         prev_metadata = {}
         if prev_entry:
+            log.debug('Previous entry exists: {}'.format(subject))
             if not update and not dry_run:
                 raise exc.RecordExists(prev_entry['content'][0],
                                        fmt=[short_path])
@@ -1170,19 +1171,18 @@ class PilotClient(NativeClient):
         sub = entry['subject']
         entry = entry['content'][0]
         full_path = self.get_path(path, project=project, relative=relative)
-        if not search_discovery.is_top_level(entry, full_path):
+        search_cli = self.get_search_client()
+        if full_subject:
+            search_cli.delete_subject(index, sub)
+        elif not search_discovery.is_top_level(entry, full_path):
             log.info('Pruning {} from multi-file-entry'.format(path))
             new_files = search.prune_files(entry, full_path)
             del_num = len(entry['files']) - len(new_files)
             entry['files'] = new_files
             self.ingest(path, entry)
             return del_num
-        search_cli = self.get_search_client()
-        if full_subject:
-            search_cli.delete_subject(index, sub)
         else:
             search_cli.delete_entry(index, sub, entry_id=entry_id)
-        return 1
 
     def delete(self, path, project=None, relative=True, recursive=False):
         """

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -210,6 +210,9 @@ class PilotClient(NativeClient):
     def get_project(self, project=None):
         return self.project.get_info(project or self.project.current)
 
+    def get_context(self, context=None):
+        return self.context.get_context(context or self.context.current)
+
     def get_index(self, project=None):
         """
         Get the configured search index for the given project. Project defaults
@@ -219,6 +222,73 @@ class PilotClient(NativeClient):
           The project to fetch info for. Defaults to current project
         """
         return self.project.get_info(project)['search_index']
+
+    def resolve_endpoint(self, url):
+        """
+        Given an http url or subject, resolve the endpoint within the URL.
+        Supports pertel style url suffix with '.e.globus.org'.
+        Raises PilotInvalidProject if protocol is not globus, http, or https
+        Example URLS:
+            globus://foo-endpoint/foo_folder/test_path
+            https://foo-endpoint/foo_folder/test_path
+            https://foo-endpoint.e.globus.org/foo_folder/test_path
+        **Parameters**
+        ``url`` (*string*)
+          The URL To resolve. Cannot be a short path or fullpath, or None will
+          be returned.
+        """
+        ep = None
+        purl = urllib.parse.urlparse(url)
+        if purl.scheme not in ['globus', 'http', 'https', '']:
+            raise exc.PilotInvalidProject('Invalid protocol '
+                                          '{}'.format(purl.scheme))
+        if purl.scheme == 'globus':
+            ep = purl.netloc
+        elif purl.scheme in ['http', 'https']:
+            if purl.netloc.endswith('.e.globus.org'):
+                ep = purl.netloc.replace('.e.globus.org', '')
+        return ep
+
+    def resolve_context(self, url):
+        """
+        Given a URL, resolve the context to which it belongs. This only works
+        for a given context that has a unique endpoint associated with the URL.
+        If multiple contexts have the same url, the first context that matches
+        will be returned.
+        **Parameters**
+        ``url`` (*string*)
+          The URL To resolve. Cannot be a short path or fullpath, or None will
+          be returned.
+        """
+        ep = self.resolve_endpoint(url)
+        if ep:
+            for name, cdata in self.context.load_all().items():
+                if cdata['projects_endpoint'] == ep:
+                    cdata['name'] = name
+                    log.debug('Resolved {} to context {}'.format(url, name))
+                    return cdata
+        log.debug('Failed to resolve context {}'.format(url))
+        return None
+
+    def resolve_project(self, url):
+        """
+        Given a URL, resolve the project to which it belongs. Returns a dict
+        containing info about the project.
+        **Parameters**
+        ``url`` (*string*)
+          The URL To resolve. Cannot be a short path or fullpath, or None will
+          be returned.
+        """
+        ep, path = self.resolve_endpoint(url), urllib.parse.urlparse(url).path
+        if ep and path:
+            for name, pdata in self.project.load_all().items():
+                if pdata['endpoint'] == ep and pdata['base_path'] in path:
+                    pdata['name'] = name
+                    log.debug('Resolved {} to project {}'.format(
+                        url, pdata['title']))
+                    return pdata
+        log.debug('Failed to resolve project {}'.format(url))
+        return None
 
     def get_short_path(self, url, project=None):
         """Given a globus HTTP URL, Globus Search subject URL, Globus URL,
@@ -238,20 +308,12 @@ class PilotClient(NativeClient):
         """
         project = project or self.project.current
         project_info = self.get_project(project)
-        purl = urllib.parse.urlparse(url)
-        ep = ''
-        if purl.scheme not in ['globus', 'http', 'https', '']:
-            raise exc.PilotInvalidProject('Invalid protocol '
-                                          '{}'.format(purl.scheme))
-        if purl.scheme == 'globus':
-            ep = purl.netloc
-        elif purl.scheme in ['http', 'https']:
-            if purl.netloc.endswith('.e.globus.org'):
-                ep = purl.netloc.replace('.e.globus.org', '')
+        ep = self.resolve_endpoint(url)
         if ep and project_info.get('endpoint') != ep:
             raise exc.PilotInvalidProject(
                 'URL {} endpoint does not match the given project {} ({} != {}'
                 ''.format(url, project, ep, project_info.get('endpoint')))
+        purl = urllib.parse.urlparse(url)
         if purl.path.startswith(project_info.get('base_path')):
             return purl.path.replace(project_info.get('base_path'),
                                      '').lstrip('/')

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -1065,8 +1065,8 @@ class PilotClient(NativeClient):
         >>> pc.download('bar/moo.txt', range='0-100,150-200')
         """
         dest = dest or os.path.basename(path)
-        return sum(self.download_parts(path, dest=dest, project=project,
-                                       range=range))
+        return sum(self.download_parts(self.get_path(path), dest=dest,
+                                       project=project, range=range))
 
     def download_globus(self, path, globus_args=None):
         result = self.transfer_file(

--- a/pilot/commands/search/delete.py
+++ b/pilot/commands/search/delete.py
@@ -11,8 +11,8 @@ log = logging.getLogger(__name__)
 @click.argument('path', type=click.Path())
 @click.option('--entry-id', default='metadata', help=('Delete a specific entry'
               ' within the search subject, or "null" for a null entry id.'))
-@click.option('--subject', default=False, help=('Delete the entire subject '
-              'comprising all of its associated entry ids'))
+@click.option('--subject', default=False, is_flag=True, help=('Delete the'
+              ' entire subject comprising all of its associated entry ids'))
 @click.option('--dry-run', is_flag=True, default=False,
               help="Show report, but don't actually delete entry/file")
 @click.option('--data', 'data_only', is_flag=True,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,6 +3,7 @@ from configobj import ConfigObj
 import os
 import json
 import copy
+import time
 import globus_sdk
 from unittest.mock import Mock
 from .mocks import (MemoryStorage, MOCK_TOKEN_SET, GlobusTransferTaskResponse,
@@ -53,6 +54,15 @@ def mock_profile(mock_config):
 def mock_projects(mock_config):
     cfg = mock_config.load()
     cfg['projects'] = MOCK_PROJECTS
+    mock_config.save(cfg)
+    return mock_config
+
+
+@pytest.fixture
+def mock_contexts(mock_config):
+    cfg = mock_config.load()
+    cfg['contexts'] = MOCK_CONTEXT
+    cfg['context'] = {'current': 'test-context', 'last_updated': time.time()}
     mock_config.save(cfg)
     return mock_config
 
@@ -155,7 +165,7 @@ def mock_sdk_response():
 
 
 @pytest.fixture
-def mock_cli_basic(monkeypatch, mock_config, mock_projects):
+def mock_cli_basic(monkeypatch, mock_config, mock_projects, mock_contexts):
     pc = client.PilotClient()
 
     def load_tokens(*args, **kwargs):
@@ -202,3 +212,14 @@ def mock_cli(mock_cli_basic, mock_transfer_client, mock_search_client,
     mock_cli_basic.get_auth_client = Mock()
     mock_cli_basic.get_http_client = Mock()
     return mock_cli_basic
+
+
+@pytest.fixture
+def mock_paths(mock_cli):
+    short_path = 'test_path'
+    return {
+        'short_path': short_path,
+        'full_path': mock_cli.get_path(short_path),
+        'subject': mock_cli.get_subject_url(short_path),
+        'http': mock_cli.get_globus_http_url(short_path),
+    }

--- a/tests/unit/mocks.py
+++ b/tests/unit/mocks.py
@@ -37,7 +37,7 @@ MOCK_CONTEXT = {'test-context': {
     'projects_cache_timeout': '86400',
     'projects_default_resource_server': 'petrel_https_server',
     'projects_default_search_index': '195a17c1-37cc-45b4-9b72-f0f7a154b143',
-    'projects_endpoint': 'cc852eda-d60b-4e3d-afbe-1f3a61688082',
+    'projects_endpoint': 'foo-project-endpoint',
     'projects_group': '',
     'scopes': ['profile', 'openid',
                'urn:globus:auth:scope:search.api.globus.org:all',

--- a/tests/unit/test_client_data_utils.py
+++ b/tests/unit/test_client_data_utils.py
@@ -87,7 +87,7 @@ def test_download_http(monkeypatch, mixed_tsv, mock_cli_basic, mock_projects):
     with patch("builtins.open", m_open):
         mock_cli_basic.download('a.tsv')
     assert get.called
-    assert get.call_args == call('a.tsv', range=None)
+    assert get.call_args == call('/foo_folder/a.tsv', range=None)
 
 
 def test_ingest(monkeypatch, mock_cli_basic, mock_sdk_response):

--- a/tests/unit/test_client_path_resolution.py
+++ b/tests/unit/test_client_path_resolution.py
@@ -97,15 +97,9 @@ def test_get_portal_url(mock_projects, mock_context):
     assert pc.get_portal_url('foo') is None
 
 
-def test_get_short_path_valid_urls(mock_cli):
-    short_path = 'test_path'
-    paths = [
-        short_path,
-        mock_cli.get_path(short_path),
-        mock_cli.get_subject_url(short_path),
-        mock_cli.get_globus_http_url(short_path),
-    ]
-    for path in paths:
+def test_get_short_path_valid_urls(mock_cli, mock_paths):
+    short_path = mock_paths['short_path']
+    for path in mock_paths.values():
         assert mock_cli.get_short_path(path) == short_path
 
     # This WORKS, even though its the wrong project, since we can't
@@ -124,3 +118,21 @@ def test_get_short_path_invalid_urls(mock_cli):
     for i in invalid:
         with pytest.raises(PilotInvalidProject):
             mock_cli.get_short_path(i)
+
+
+def test_resolve_project(mock_cli, mock_paths):
+    paths = mock_paths['short_path'], mock_paths['full_path']
+    urls = mock_paths['subject'], mock_paths['http']
+    for path in paths:
+        assert mock_cli.resolve_project(path) is None
+    for url in urls:
+        assert mock_cli.resolve_project(url) == mock_cli.get_project()
+
+
+def test_resolve_context(mock_cli, mock_paths):
+    paths = mock_paths['short_path'], mock_paths['full_path']
+    urls = mock_paths['subject'], mock_paths['http']
+    for path in paths:
+        assert mock_cli.resolve_context(path) is None
+    for url in urls:
+        assert mock_cli.resolve_context(url) == mock_cli.get_context()

--- a/tests/unit/test_search_discovery.py
+++ b/tests/unit/test_search_discovery.py
@@ -78,6 +78,7 @@ def test_get_sub_in_collection_similar_file(mock_cli):
     # Precise match required, returns None
     assert get_sub_in_collection(foo, entries, precise=True) is None
 
+
 def test_get_sub_with_dirs(mock_multi_file_result, mock_cli):
     gmeta = mock_multi_file_result['gmeta']
     gmeta[0]['subject'] = mock_cli.get_subject_url('dir/file1.txt')


### PR DESCRIPTION
**Note**: This is a single commit, but depends on #122 and #88. I'll keep it as a draft until those are merged. 

This in part addresses the issue to use universal identifiers (#123)
instead of short paths. If a user needs to download a file and
only has the full url, they can now call the native cli methods.
For example:
```
    short_path = pc.get_short_path(url)
    pc.download(short_path)
```
get_short_path() is pretty flexible, and `url` can be a:
* Globus Search subject
* Globus HTTP URL
* Globus URL (same as subject)
* full path in project
* shortpath

Each will raise an invalid project exception if some parts of the URL don't match, such as if the Globus endpoint does not match the endpoint configured for the project. The only exception above is `shortpath`, which is ambiguous and _must_ refer to the current project. 