### PR TITLE
Set version on post_search queries

### DIFF
--- a/pilot/client.py
+++ b/pilot/client.py
@@ -569,6 +569,7 @@ class PilotClient(NativeClient):
             },
             'limit': 100,
             'offset': 0,
+            'result_format_version': '2017-09-01',
         }
         search_data.update(custom_params or {})
         return sc.post_search(index, search_data).data


### PR DESCRIPTION
This will make pliot use the older style, prior to the newer style
coming out in a few days.

I started on switching Pilot over to the newer style, but it ended
up being a little more complex than I expected. Since we added
multi-file-entries, Pilot doesn't always get_subject when you ask
it to fetch a subject. Sometimes it needs to do a combination to
resolve whether you're talking about an exact search record, or a
file within a search record. The mechanisms for resolving entries
and files within entries are pretty well coupled to the older style.