### PR TITLE
WIP switching over to the new search style

### DIFF
--- a/pilot/commands/search/search_commands.py
+++ b/pilot/commands/search/search_commands.py
@@ -71,7 +71,9 @@ def get_location_info(entry):
               help='Only list results relative to project')
 @click.option('--all', 'all_recs', default=False, is_flag=True,
               help='Do not filter on project')
-def list_command(path, output_json, limit, relative, all_recs):
+@click.option('--entry-id', 'entry_id', default='metadata',
+              help='GS Entry id to use for search data.')
+def list_command(path, output_json, limit, relative, all_recs, entry_id):
     # Should require login if there are publicly visible records
     pc = commands.get_pilot_client()
     project = pc.project.current
@@ -79,7 +81,6 @@ def list_command(path, output_json, limit, relative, all_recs):
     if all_recs:
         search_params['filters'], relative = [], False
     search_results = pc.search(project=project, custom_params=search_params)
-    log.debug(search_results)
     if output_json:
         click.echo(json.dumps(search_results, indent=4))
         return
@@ -100,7 +101,7 @@ def list_command(path, output_json, limit, relative, all_recs):
             log.debug('Skipping result {}'.format(result['subject']))
             continue
 
-        data = dict(parse_result(result['content'][0], items))
+        data = dict(parse_result(result['entries'][entry_id], items))
         parsed = [data.get(name) for name in items]
         parsed += [get_short_path(result) if relative else result['subject']]
         parsed = [str(p) for p in parsed]

--- a/pilot/search_discovery.py
+++ b/pilot/search_discovery.py
@@ -30,7 +30,8 @@ def get_sub_in_collection(subject, entries, precise=True):
     entry = get_entry_with_matching_subject(entries, subject)
     if entry is None or precise is False:
         return entry
-    urls = [m.get('url') for m in entry['content'][0].get('files', [])]
+    urls = [m.get('url') for m in entry['entries']['metadata'].get('files',
+                                                                   [])]
     sub_path = urllib.parse.urlparse(subject).path
     for url in urls:
         log.debug('Checking {}'.format(url))
@@ -99,3 +100,13 @@ def get_paths(entry):
 def is_top_level(entry, subject):
     sub_path = urllib.parse.urlparse(subject).path
     return all([f_path.startswith(sub_path) for f_path in get_paths(entry)])
+
+
+def key_entries_by_entry_id(entries):
+    return [
+        {
+            'subject': ent.get('subject'),
+            'entries': {e['entry_id']: e['content']
+                        for e in ent['entries']}
+        } for ent in entries
+    ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -97,7 +97,8 @@ def mock_search_data():
 def mock_search_results(mock_search_data):
     return {'@datatype': 'GSearchResult', '@version': '2017-09-01', 'count': 1,
             'gmeta': [{'@datatype': 'GMetaResult', '@version': '2017-09-01',
-                       'content': [mock_search_data],
+                       'entries': [{'content': mock_search_data,
+                                    'entry_id': 'metadata'}],
                        'subject': 'foo_folder'}],
             'offset': 0, 'total': 1}
 
@@ -109,8 +110,22 @@ def mock_multi_file_result(mock_search_results):
     with open(mf_filename) as f:
         multi_file = json.load(f)
     sub = 'globus://foo-project-endpoint/foo_folder/multi_file'
-    data['gmeta'] = [{'content': [multi_file], 'subject': sub}]
+    data['gmeta'] = [
+        {'entries': [{'content': multi_file, 'entry_id': 'metadata'}],
+         'subject': sub}
+    ]
     return data
+
+
+@pytest.fixture
+def mock_subject_data(mock_multi_file_result):
+    content = mock_multi_file_result['gmeta'][0]['entries'][0]['content']
+    mmfe = {
+        'entry_ids': ['metadata'],
+        'content': [content],
+        'subject': mock_multi_file_result['gmeta'][0]['subject']
+    }
+    return mmfe
 
 
 @pytest.fixture

--- a/tests/unit/test_client_upload.py
+++ b/tests/unit/test_client_upload.py
@@ -55,8 +55,10 @@ def test_update_mfe_with_file(mock_cli, mock_transfer_log,
                               mock_multi_file_result):
     sub = mock_cli.get_subject_url('my_folder/multi_file')
     mock_multi_file_result['gmeta'][0]['subject'] = sub
-    gse = Mock(return_value=mock_multi_file_result['gmeta'])
-    mock_cli.list_entries = gse
+    gse = Mock(return_value=mock_multi_file_result)
+    from pprint import pprint
+    pprint(gse)
+    mock_cli.search = gse
     metadata = mock_cli.upload(EMPTY_TEST_FILE, 'my_folder/multi_file',
                                update=True)['new_metadata']
     assert len(mock_multi_file_result['gmeta'][0]['content'][0]['files']) == 4


### PR DESCRIPTION
This is a first pass on switching over to the newer search style. It mostly works, but doesn't fix all tests and still needs some changes around ingest. 

The main problem with switching comes from how pilot resolves multi-file entries. A given subject may
resolve directly to a subject in search, or it may refer to a file within a subject. Pilot needs to
be able to resolve both seamlessly. When it cannot resolve directly to a subject, it needs to fall back on
a larger search to narrow down which subject is the best candidate for the file the user is talking about. This means both the Globus SDK `get_subject()` and `post_search()` need to behave similarly across all usages (Which has now changed a bit in the SDK).

I'll try to finish this after a pass on the XPCS data. The last merge will force pilot to use the older style of search results. 