### PR TITLE
Feature: Pilot config file configurable with env var or optional param

### DIFF
--- a/pilot/commands/auth/auth_commands.py
+++ b/pilot/commands/auth/auth_commands.py
@@ -81,8 +81,8 @@ def logout(purge):
         click.secho('You have been logged out.', fg='green')
     else:
         click.echo('No user logged in, no tokens to clear.')
-    if purge and os.path.exists(pc.config.CFG_FILENAME):
-        os.unlink(pc.config.CFG_FILENAME)
+    if purge and os.path.exists(pc.config_file):
+        os.unlink(pc.config_file)
         click.secho('All local user info and logs have been deleted.',
                     fg='green')
 
@@ -142,7 +142,8 @@ def profile_command(interactive, local_endpoint):
               ('Identity: ', pc.profile.load_option('preferred_username')),
               ('Local Endpoint:', info.get('local_endpoint_name')),
               ('Local Path:', info.get('local_endpoint_path')),
-              ('Endpoint UUID:', info.get('local_endpoint'))
+              ('Endpoint UUID:', info.get('local_endpoint')),
+              ('Config File:', pc.config_file),
               ]
     pstr = '\n'.join(['{:16}{}'.format(t, v) for t, v in pitems])
     click.echo('Your Profile: \n{}\n'.format(pstr))

--- a/pilot/commands/main.py
+++ b/pilot/commands/main.py
@@ -28,7 +28,7 @@ def cli(ctx):
             click.secho('Success!', fg='green')
         except Exception:
             click.secho(f'Failed! Try removing '
-                        f'{pc.config.CFG_FILENAME} and logging in '
+                        f'{pc.config_file} and logging in '
                         f'again.', fg='red')
     if pc.is_logged_in():
         if pc.context.is_cache_stale():

--- a/pilot/config.py
+++ b/pilot/config.py
@@ -11,10 +11,9 @@ log = logging.getLogger(__name__)
 
 
 class Config():
-    CFG_FILENAME = os.path.expanduser('~/.pilot1.cfg')
 
-    def __init__(self, filename=None):
-        self.filename = filename or self.CFG_FILENAME
+    def __init__(self, filename):
+        self.filename = filename
         cfg = self.load()
 
         if not cfg:
@@ -23,7 +22,7 @@ class Config():
 
     def migrate_to_configobj(self):
         cfg = self.load()
-        old_cfg = ConfigParserTokenStorage(filename=self.CFG_FILENAME)
+        old_cfg = ConfigParserTokenStorage(filename=self.filename)
         cfg['tokens'] = old_cfg.read_tokens()
         cfg['pilot'] = {'version': __version__}
         cfg.write()
@@ -84,8 +83,8 @@ class ConfigSection:
 
     SECTION = None
 
-    def __init__(self):
-        self.config = Config()
+    def __init__(self, config_file):
+        self.config = Config(config_file)
         if not self.SECTION:
             raise NotImplementedError('SECTION must be set on Config Section '
                                       'obj')

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -39,7 +39,7 @@ def mock_config(monkeypatch):
     mock_cfg = MockConfig()
     monkeypatch.setattr(config.Config, 'load', mock_cfg.load)
     monkeypatch.setattr(config.Config, 'save', mock_cfg.save)
-    return config.Config()
+    return config.Config('/tmp/test_pilot.cfg')
 
 
 @pytest.fixture

--- a/tests/unit/test_client_data_utils.py
+++ b/tests/unit/test_client_data_utils.py
@@ -114,7 +114,8 @@ def test_get_search_entry(monkeypatch, mock_cli_basic):
     assert mock_cli_basic.get_search_entry('foo') == 'myresult'
     search_cli.get_subject.assert_called_with(
         'foo-search-index',
-        'globus://foo-project-endpoint/foo_folder/foo'
+        'globus://foo-project-endpoint/foo_folder/foo',
+        result_format_version='2017-09-01',
     )
 
     class MockException(Exception):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,7 +6,7 @@ def test_config_section_save_load_values(mock_config):
     class TestSection(config.ConfigSection):
         SECTION = 'mysection'
 
-    cfg = TestSection()
+    cfg = TestSection('/tmp/test_pilot.cfg')
     cfg.save_option('foo', 'bar')
     assert cfg.load_option('foo') == 'bar'
 

--- a/tests/unit/test_profile.py
+++ b/tests/unit/test_profile.py
@@ -3,14 +3,14 @@ from tests.unit.mocks import MOCK_PROFILE
 
 
 def test_save_user_info(mock_config):
-    pfile = profile.Profile()
+    pfile = profile.Profile('/tmp/pilot-config.cfg')
     assert pfile.load_user_info() == {}
     pfile.save_user_info(MOCK_PROFILE)
     assert pfile.load_user_info() == MOCK_PROFILE
 
 
 def test_profile_getter_setters(mock_config):
-    pfile = profile.Profile()
+    pfile = profile.Profile('/tmp/pilot-config.cfg')
     assert pfile.load_user_info() == {}
     pfile.save_user_info(MOCK_PROFILE)
     assert pfile.organization == 'The French Government Central Laboratory'

--- a/tests/unit/test_transfer_log.py
+++ b/tests/unit/test_transfer_log.py
@@ -3,7 +3,7 @@ from pilot.transfer_log import TransferLog
 
 
 def test_add_transfer_log(mock_config):
-    tl = TransferLog()
+    tl = TransferLog('/tmp/pilot-log.cfg')
     cfg = tl.config.load()
     assert cfg['transfer_log'] == {}
     assert tl.get_log() == []
@@ -15,7 +15,7 @@ def test_add_transfer_log(mock_config):
 
 
 def test_get_transfer_log(mock_config):
-    tl = TransferLog()
+    tl = TransferLog('/tmp/pilot-log.cfg')
     gccr = GlobusTransferTaskResponse()
     tl.add_log(gccr, 'foo/bar')
 
@@ -27,7 +27,7 @@ def test_get_transfer_log(mock_config):
 
 
 def test_update_transfer_log(mock_config):
-    tl = TransferLog()
+    tl = TransferLog('/tmp/pilot-log.cfg')
     gccr = GlobusTransferTaskResponse()
     tl.add_log(gccr, 'foo/bar')
     tl.update_log(gccr.data['task_id'], 'complete')


### PR DESCRIPTION
@ryanchard These changes are for you! 

This should allow for setting two separate configs for different contexts. Alternate configs are settable both with env vars or by passing an optional filename to the PilotClient (env var takes precedence). This should handle both the case for running the Pilot CLI and for scripting, and should allow you to have dedicated configs for APS projects, where you want to ensure one particular context. 

Set config file by env var:

    export PILOT_CONFIG="~/.pilot1-xpcs.cfg"

Set config file via scripting:

    from pilot.client import PilotClient
    pc = PilotClient(config_file='~/.pilot1-ssx.cfg')