### PR TITLE
Upgrade jsonschema to >= 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pytz
 fair-research-login>=0.1.5
 click>=7.0
 colorama>=0.4.1
-jsonschema<3.0,>=2.5
+jsonschema>=3.0.0
 pandas
 tableschema
 configobj


### PR DESCRIPTION
We previously had a requirement for jsonschema < 3.0.0, which I believe was from tableschema. This caused problems with FuncX. Thankfully, tableschema updated their stuff so we can remove this restriction. 